### PR TITLE
Fe/#28/Today-broadcast-UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react-hook-form": "^7.58.1",
         "react-icons": "^5.5.0",
         "react-kakao-maps-sdk": "^1.2.0",
+        "react-router-dom": "^7.6.2",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -2394,6 +2395,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
@@ -4706,6 +4716,44 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4868,6 +4916,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react-hook-form": "^7.58.1",
     "react-icons": "^5.5.0",
     "react-kakao-maps-sdk": "^1.2.0",
+    "react-router-dom": "^7.6.2",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/frontend/src/components/DetailStores/DetailStores.tsx
+++ b/frontend/src/components/DetailStores/DetailStores.tsx
@@ -6,53 +6,59 @@ import {
   FiClock,
   FiPhone,
   FiFileText,
-  FiChevronLeft,
+  FiX,
   FiTv,
 } from "react-icons/fi";
 import { FaUtensils } from "react-icons/fa";
-import { dummyRestaurantDetail } from "../../data/dummyRestaurantDetail"; // 변경된 import
+import type { RestaurantDetail } from "../../types/restaurant.types";
 
 const TABS = ["홈", "메뉴", "중계"] as const;
 type Tab = (typeof TABS)[number];
 
 interface RestaurantDetailComponentProps {
+  detail: RestaurantDetail;
   onClose: () => void;
 }
 
 export default function RestaurantDetailComponent({
+  detail,
   onClose,
 }: RestaurantDetailComponentProps) {
   const [currentTab, setCurrentTab] = useState<Tab>("홈");
 
   return (
-    <aside className="fixed left-0 top-0 h-full w-[370px] z-[100] bg-white shadow-2xl border-r border-gray-100 flex flex-col font-pretendard">
-      {/* 닫기(뒤로가기) 버튼 */}
-      <button
-        onClick={onClose}
-        className="fixed left-[350px] top-1/2 -translate-y-1/2 z-[120] w-12 h-12 rounded-full bg-white shadow-lg border border-gray-100 flex items-center justify-center hover:bg-emerald-50 transition"
-        aria-label="상세보기 닫기"
-        style={{ boxShadow: "0 2px 16px 0 rgba(0,0,0,0.10)" }}
-      >
-        <FiChevronLeft className="text-emerald-500 text-2xl" />
-      </button>
+    <aside className="fixed left-0 top-0 h-full w-[430px] z-[100] bg-white shadow-2xl border-r border-gray-100 flex flex-col font-pretendard">
+      {/* 상단: 로고와 닫기(X) 버튼을 같은 flex row에 배치 */}
+      <div className="relative h-12 border-b border-gray-100 bg-white">
+        <span className="absolute left-8 top-1/2 -translate-y-1/2 text-2xl font-bold tracking-tight text-emerald-600 font-pretendard">
+          Playce
+        </span>
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-1/2 -translate-y-1/2 w-10 h-10 flex items-center justify-center rounded-full hover:bg-emerald-50 transition"
+          aria-label="상세보기 닫기"
+        >
+          <FiX className="text-emerald-500 text-2xl" />
+        </button>
+      </div>
 
       {/* 이미지 */}
-      <div className="w-full h-44 bg-gray-100 flex items-center justify-center relative">
-        {dummyRestaurantDetail.img_list[0] ? (
+      <div className="w-full h-56 bg-gradient-to-tr from-emerald-50 via-white to-orange-50 flex items-center justify-center relative">
+        {detail.img_list[0] ? (
           <img
-            src={dummyRestaurantDetail.img_list[0]}
-            alt={dummyRestaurantDetail.store_name}
-            className="w-full h-full object-cover"
+            src={detail.img_list[0]}
+            alt={detail.store_name}
+            className="w-full h-full object-cover rounded-b-xl"
           />
         ) : (
           <span className="text-gray-400">이미지 없음</span>
         )}
         {/* 저장/공유 버튼 */}
-        <div className="absolute left-4 top-4 flex gap-2 z-10">
-          <button className="bg-white/80 rounded-full p-2 shadow hover:bg-emerald-100 transition">
+        <div className="absolute left-6 top-6 flex gap-3 z-10">
+          <button className="bg-white/90 rounded-full p-2 shadow hover:bg-orange-50 transition">
             <FiStar className="text-emerald-500 text-lg" />
           </button>
-          <button className="bg-white/80 rounded-full p-2 shadow hover:bg-emerald-100 transition">
+          <button className="bg-white/90 rounded-full p-2 shadow hover:bg-orange-50 transition">
             <FiShare2 className="text-emerald-500 text-lg" />
           </button>
         </div>
@@ -63,11 +69,11 @@ export default function RestaurantDetailComponent({
         {TABS.map((tab) => (
           <button
             key={tab}
-            className={`flex-1 py-3 text-sm font-semibold flex items-center justify-center gap-1 transition-all
+            className={`flex-1 py-3 text-base font-semibold flex items-center justify-center gap-1 transition-all
               ${
                 currentTab === tab
-                  ? "text-gray-900 border-b-2 border-gray-200 bg-white"
-                  : "text-gray-400 hover:text-gray-700"
+                  ? "text-emerald-600 border-b-2 border-emerald-400 bg-white"
+                  : "text-gray-400 hover:text-emerald-600"
               }`}
             onClick={() => setCurrentTab(tab)}
             style={{ background: "none" }}
@@ -80,31 +86,27 @@ export default function RestaurantDetailComponent({
       </div>
 
       {/* 탭 내용 */}
-      <div className="flex-1 p-5 text-sm overflow-y-auto">
+      <div className="flex-1 p-6 text-base overflow-y-auto">
         {/* 홈 탭 */}
         {currentTab === "홈" && (
           <div className="flex flex-col gap-4">
-            <h2 className="text-lg font-bold mb-2">
-              {dummyRestaurantDetail.store_name}
-            </h2>
-            <p className="mb-2 text-gray-700">
-              {dummyRestaurantDetail.description}
-            </p>
+            <h2 className="text-2xl font-bold mb-2">{detail.store_name}</h2>
+            <p className="mb-2 text-gray-700">{detail.description}</p>
             <div className="flex items-center gap-2">
               <FiMapPin className="text-xl" />
-              <span>{dummyRestaurantDetail.address}</span>
+              <span>{detail.address}</span>
             </div>
             <div className="flex items-center gap-2">
               <FiClock className="text-xl" />
-              <span>{dummyRestaurantDetail.opening_hours}</span>
+              <span>{detail.opening_hours}</span>
             </div>
             <div className="flex items-center gap-2">
               <FiPhone className="text-xl" />
-              <span>{dummyRestaurantDetail.phone}</span>
+              <span>{detail.phone}</span>
             </div>
             <div className="flex items-center gap-2">
               <FiFileText className="text-xl" />
-              <span>{dummyRestaurantDetail.type}</span>
+              <span>{detail.type}</span>
             </div>
           </div>
         )}
@@ -112,12 +114,11 @@ export default function RestaurantDetailComponent({
         {/* 메뉴 탭 */}
         {currentTab === "메뉴" && (
           <ul className="grid grid-cols-1 gap-3">
-            {dummyRestaurantDetail.menus &&
-            dummyRestaurantDetail.menus.length > 0 ? (
-              dummyRestaurantDetail.menus.map((menu, idx) => (
+            {detail.menus && detail.menus.length > 0 ? (
+              detail.menus.map((menu, idx) => (
                 <li
                   key={idx}
-                  className="flex items-center gap-3 px-4 py-3 rounded-lg bg-gray-50 shadow-sm hover:bg-gray-100 transition group"
+                  className="flex items-center gap-3 px-5 py-3 rounded-lg bg-gray-50 shadow-sm hover:bg-gray-100 transition group"
                 >
                   <FaUtensils className="text-emerald-400 text-lg" />
                   <span className="font-medium text-gray-700 group-hover:text-emerald-700 transition">
@@ -134,8 +135,8 @@ export default function RestaurantDetailComponent({
         {/* 중계 탭 */}
         {currentTab === "중계" && (
           <ul className="flex flex-col gap-4">
-            {dummyRestaurantDetail.broadcasts.length > 0 ? (
-              dummyRestaurantDetail.broadcasts.map((b, idx) => (
+            {detail.broadcasts.length > 0 ? (
+              detail.broadcasts.map((b, idx) => (
                 <li
                   key={idx}
                   className="rounded-xl bg-gradient-to-r from-emerald-50 to-white shadow p-4 flex flex-col gap-1 border border-emerald-100"

--- a/frontend/src/components/Map/PlayceMap.tsx
+++ b/frontend/src/components/Map/PlayceMap.tsx
@@ -4,51 +4,55 @@ import useMapStore from "../../stores/mapStore";
 import PlayceMapMarker from "./PlayceMapMarker";
 import PlayceModal from "./PlayceModal";
 import RestaurantDetailComponent from "../DetailStores/DetailStores";
-import type { spot } from "../../types/map";
+import React from "react";
+import { dummyRestaurantDetails } from "../../data/dummyRestaurantDetail";
+import type { RestaurantDetail } from "../../types/restaurant.types";
 
 const PlayceMap: React.FC = () => {
   const { position, spots, openedModal, closeModal, setRefreshBtn } =
     useMapStore();
   const [isDetailOpen, setIsDetailOpen] = useState(false);
-  const [selectedSpot, setSelectedSpot] = useState<spot | null>(null);
+  const [selectedDetail, setSelectedDetail] = useState<RestaurantDetail | null>(
+    null
+  );
 
   return (
     <>
       <Map
         className="w-full h-full"
         center={position}
-        onClick={() => {
-          closeModal();
-        }}
-        onDragEnd={() => {
-          setRefreshBtn(true);
-        }}
+        onClick={closeModal}
+        onDragEnd={() => setRefreshBtn(true)}
       >
-        {spots.map((spot) => (
-          <div key={spot.id}>
-            <PlayceMapMarker spot={spot} />
-            {openedModal === spot.id && (
-              <PlayceModal
-                spot={spot}
-                onDetailClick={(spot, detail) => {
-                  closeModal();
-                  setSelectedSpot(spot);
-                  setIsDetailOpen(true);
-                  console.log(detail);
-                }}
-                onClose={closeModal}
-              />
-            )}
-          </div>
-        ))}
+        {spots.map((spot) => {
+          const detail = dummyRestaurantDetails.find((d) => d.id === spot.id);
+          return (
+            <React.Fragment key={spot.id}>
+              <PlayceMapMarker spot={spot} />
+              {openedModal === spot.id && detail && (
+                <PlayceModal
+                  spot={spot}
+                  detail={detail}
+                  // 이벤트 버블링 문제 해결을 위해 onMouseDown에서 stopPropagation!
+                  onDetailClick={(_spot, detail) => {
+                    setSelectedDetail(detail!);
+                    setIsDetailOpen(true);
+                    closeModal();
+                  }}
+                  onClose={closeModal}
+                />
+              )}
+            </React.Fragment>
+          );
+        })}
       </Map>
-      {isDetailOpen && selectedSpot && (
+      {isDetailOpen && selectedDetail && (
         <div className="fixed left-0 top-0 h-full w-[370px] z-[9999] shadow-2xl bg-white">
           <RestaurantDetailComponent
-            // spot={selectedSpot}
+            detail={selectedDetail}
             onClose={() => {
               setIsDetailOpen(false);
-              setSelectedSpot(null);
+              setSelectedDetail(null);
             }}
           />
         </div>

--- a/frontend/src/components/Map/PlayceModal.tsx
+++ b/frontend/src/components/Map/PlayceModal.tsx
@@ -10,15 +10,15 @@ import {
   FiX,
 } from "react-icons/fi";
 
+const defaultImage =
+  "https://images.pexels.com/photos/262047/pexels-photo-262047.jpeg?auto=compress&w=400&q=80";
+
 interface PlayceModalProps {
-  spot: spot; // 위치 정보
-  detail?: RestaurantDetail; // 상세 정보 (API에서 받아오거나, 없으면 undefined)
+  spot: spot;
+  detail?: RestaurantDetail;
   onDetailClick: (spot: spot, detail?: RestaurantDetail) => void;
   onClose: () => void;
 }
-
-const defaultImage =
-  "https://images.pexels.com/photos/262047/pexels-photo-262047.jpeg?auto=compress&w=400&q=80";
 
 const PlayceModal = ({
   spot,
@@ -72,7 +72,11 @@ const PlayceModal = ({
       </div>
       {/* 상세보기 버튼 */}
       <button
-        onClick={() => onDetailClick(spot, detail)}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={() => {
+          console.log("PlayceModal 상세보기 버튼 클릭!", spot, detail);
+          onDetailClick(spot, detail);
+        }}
         className="w-full py-2 rounded-lg bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition"
       >
         상세보기

--- a/frontend/src/data/dummyFavorites.ts
+++ b/frontend/src/data/dummyFavorites.ts
@@ -3,18 +3,18 @@ import type { FavoriteStore } from "../types/Favorite";
 export const dummyFavorites: FavoriteStore[] = [
   {
     store_id: 1,
-    store_name: "홍콩반점",
+    store_name: "더 맥주 광화문점",
     main_img:
-      "https://images.pexels.com/photos/262047/pexels-photo-262047.jpeg",
-    address: "서울시 강남구",
-    type: "중식",
+      "https://images.pexels.com/photos/1267320/pexels-photo-1267320.jpeg?auto=compress&w=400&q=80",
+    address: "서울시 종로구 세종대로",
+    type: "펍/호프",
   },
   {
     store_id: 2,
-    store_name: "피자헛",
+    store_name: "풋볼펍 홍대",
     main_img:
-      "https://images.pexels.com/photos/315755/pexels-photo-315755.jpeg",
-    address: "서울시 마포구",
-    type: "피자",
+      "https://images.pexels.com/photos/338713/pexels-photo-338713.jpeg?auto=compress&w=400&q=80",
+    address: "서울시 마포구 양화로",
+    type: "스포츠 바",
   },
 ];

--- a/frontend/src/data/dummyRestaurantDetail.ts
+++ b/frontend/src/data/dummyRestaurantDetail.ts
@@ -1,34 +1,109 @@
 import type { RestaurantDetail } from "../types/restaurant.types";
 
-export const dummyRestaurantDetail: RestaurantDetail = {
-  store_name: "리버풀펍 바(BAR)",
-  address: "서울 중구 북창동",
-  phone: "0507-1332-4885",
-  opening_hours: "매일 18:00 ~ 03:00",
-  menus: ["피자", "치킨", "볶음우동", "생맥주500ml"],
-  type: "펍/호프",
-  img_list: [
-    "https://images.pexels.com/photos/262047/pexels-photo-262047.jpeg?auto=compress&w=400&q=80",
-  ],
-  description: "다양한 맥주를 즐기는 시원한 공간",
-  broadcasts: [
-    {
-      match_date: "2025-07-01",
-      match_time: "21:00",
-      sport: "축구",
-      league: "EPL",
-      team_one: "리버풀",
-      team_two: "맨체스터 Utd",
-      etc: "빅매치",
-    },
-    {
-      match_date: "2025-07-02",
-      match_time: "20:00",
-      sport: "야구",
-      league: "KBO",
-      team_one: "두산",
-      team_two: "LG",
-      etc: "",
-    },
-  ],
-};
+export const dummyRestaurantDetails: RestaurantDetail[] = [
+  {
+    id: 1,
+    store_name: "리버풀펍 바(BAR)",
+    address: "서울 중구 북창동",
+    phone: "0507-1332-4885",
+    opening_hours: "매일 18:00 ~ 03:00",
+    menus: ["피자", "치킨", "소시지 플래터", "생맥주 500ml"],
+    type: "펍/호프",
+    img_list: [
+      "https://images.pexels.com/photos/262047/pexels-photo-262047.jpeg?auto=compress&w=400&q=80",
+    ],
+    description: "리버풀 팬들의 아지트! EPL 빅매치를 생중계합니다.",
+    broadcasts: [
+      {
+        match_date: "2025-07-01",
+        match_time: "21:00",
+        sport: "축구",
+        league: "EPL",
+        team_one: "리버풀",
+        team_two: "맨체스터 Utd",
+        etc: "빅매치",
+      },
+    ],
+  },
+  {
+    id: 2,
+    store_name: "스포츠존 홍대",
+    address: "서울 마포구 홍대입구역 근처",
+    phone: "02-3456-7890",
+    opening_hours: "매일 17:00 ~ 04:00",
+    menus: ["버팔로윙", "감자튀김", "수제 맥주", "하이볼"],
+    type: "스포츠 바",
+    img_list: [
+      "https://images.pexels.com/photos/1267320/pexels-photo-1267320.jpeg?auto=compress&w=400&q=80",
+    ],
+    description: "모든 종목 중계 OK! 대형 스크린과 함께하는 뜨거운 응원",
+    broadcasts: [
+      {
+        match_date: "2025-07-03",
+        match_time: "08:00",
+        sport: "야구",
+        league: "MLB",
+        team_one: "LA 다저스",
+        team_two: "뉴욕 양키스",
+        etc: "류현진 선발 예정",
+      },
+      {
+        match_date: "2025-07-03",
+        match_time: "23:00",
+        sport: "테니스",
+        league: "윔블던",
+        team_one: "조코비치",
+        team_two: "알카라스",
+        etc: "남자 단식 준결승",
+      },
+    ],
+  },
+  {
+    id: 3,
+    store_name: "비어킹 건대점",
+    address: "서울 광진구 건대입구역 인근",
+    phone: "02-2222-3333",
+    opening_hours: "평일 17:00 ~ 02:00 / 주말 17:00 ~ 03:00",
+    menus: ["오징어튀김", "모둠안주", "생맥주", "칵테일"],
+    type: "펍",
+    img_list: [
+      "https://images.pexels.com/photos/1267322/pexels-photo-1267322.jpeg?auto=compress&w=400&q=80",
+    ],
+    description: "축구, 농구, UFC까지! 다같이 보는 짜릿한 순간",
+    broadcasts: [
+      {
+        match_date: "2025-07-05",
+        match_time: "13:00",
+        sport: "격투기",
+        league: "UFC",
+        team_one: "정찬성",
+        team_two: "맥스 할로웨이",
+        etc: "페더급 빅매치",
+      },
+    ],
+  },
+  {
+    id: 4,
+    store_name: "골든골 사커바",
+    address: "부산 해운대구",
+    phone: "051-555-7777",
+    opening_hours: "매일 18:00 ~ 03:00",
+    menus: ["나쵸", "핫도그", "버드와이저", "하이네켄"],
+    type: "스포츠 바",
+    img_list: [
+      "https://images.pexels.com/photos/1395967/pexels-photo-1395967.jpeg?auto=compress&w=400&q=80",
+    ],
+    description: "바다 보며 보는 축구는 또 다른 재미! 외국인 손님도 많아요.",
+    broadcasts: [
+      {
+        match_date: "2025-07-06",
+        match_time: "22:00",
+        sport: "축구",
+        league: "유로 2024",
+        team_one: "프랑스",
+        team_two: "독일",
+        etc: "4강전",
+      },
+    ],
+  },
+];

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
-)
+  </StrictMode>
+);

--- a/frontend/src/types/restaurant.types.ts
+++ b/frontend/src/types/restaurant.types.ts
@@ -9,6 +9,7 @@ export interface Broadcast {
 }
 
 export interface RestaurantDetail {
+  id: number;
   store_name: string;
   address: string;
   phone: string;


### PR DESCRIPTION
## 📎 관련 이슈
#28 


## 📌 PR 설명
- 더미데이터(스팟/가게 정보) 구조를 spot 기준으로 새롭게 정의했습니다. (1~4 위치, 가게 데이터)
- 지도상의 마커(spot)와 상세보기(가게 detail)가 1:1로 연결되도록 전체 로직을 리팩토링
- 마커 클릭 → 모달 → 상세보기(사이드바)까지 자연스럽게 연동되도록 UI/상태/이벤트 구조를 개선


## ✅ 작업 내용
-  더미데이터(spot, detail) 구조 재정의 및 매칭
- PlayceMap, PlayceModal, RestaurantDetailComponent 상태/이벤트 구조 개선
- 상세보기 UI 디자인/레이아웃 개선 (사이드바 통일감, 닫기 버튼 위치/스타일 등)
- 이벤트 버블링 이슈 해결 (onMouseDown stopPropagation 등)
- 코드 및 CSS 리팩토링


## 🧪 테스트 방법 (선택)
어떻게 테스트했는지, 테스트할 방법이 있다면 적어주세요.


## 💬 기타
- 상세보기 UI

![스크린샷 2025-06-27 122251](https://github.com/user-attachments/assets/dbd04e3f-c019-4263-ad81-f5d38edb8fb5)

