### PR TITLE
Fe/#48/broadcast register edit

### DIFF
--- a/frontend/src/components/Mypage/RestaurantManage/Broadcasts/BroadcastView.tsx
+++ b/frontend/src/components/Mypage/RestaurantManage/Broadcasts/BroadcastView.tsx
@@ -4,6 +4,8 @@ import TabList from "./TabLists";
 import { FaBars, FaPlus, FaRegCalendarAlt } from "react-icons/fa";
 import useBroadcastStore, { dateInfo } from "../../../../stores/broadcastStore";
 import Calendar from "./Calendar";
+import { useState } from "react";
+import BroadcastFormModal from "../modals/BroadcastFormModal";
 
 const BroadcastView = () => {
   // 날짜 설정
@@ -44,11 +46,13 @@ const BroadcastView = () => {
     setDate(1);
   };
 
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
     <div className="flex flex-col p-3">
       <div className="flex text-[28px] items-center justify-between mb-5 gap-3">
         {/* 중앙 맞추기용 사용하지 않는 버튼 */}
-        <button className="text-[25px]">
+        <button className="text-[25px]" onClick={() => setIsModalOpen(true)}>
           <FaPlus />
         </button>
 
@@ -90,6 +94,18 @@ const BroadcastView = () => {
         </button>
       </div>
       {viewOption === "tab" ? <TabList /> : <Calendar />}
+
+      {isModalOpen && (
+        <BroadcastFormModal
+          mode="create"
+          onSubmit={(data) => {
+            // TODO: 등록 로직 (API 호출 등)
+            console.log("중계 등록됨:", data);
+            setIsModalOpen(false); // 모달 닫기
+          }}
+          onClose={() => setIsModalOpen(false)}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/Mypage/RestaurantManage/modals/BroadcastFormModal.tsx
+++ b/frontend/src/components/Mypage/RestaurantManage/modals/BroadcastFormModal.tsx
@@ -1,0 +1,178 @@
+import { DatePicker, TimePicker } from "antd";
+import useBroadcastFormStore from "../../../../stores/broadcastFormStore";
+import { sportsMap } from "../../../../data/sports";
+import type { BroadcastFormData, BroadcastFormModalProps } from "../../../../types/broadcastForm";
+
+const BroadcastFormModal = ({
+  mode,
+  onSubmit,
+  onClose,
+}: BroadcastFormModalProps) => {
+  const {
+    date,
+    time,
+    sport,
+    league,
+    team1,
+    team2,
+    note,
+    setDate,
+    setTime,
+    setSport,
+    setLeague,
+    setteam1,
+    setteam2,
+    setNote,
+    resetForm,
+  } = useBroadcastFormStore();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!date || !time || !sport || !league) {
+      alert("모든 필수 항목을 입력해주세요.");
+      return;
+    }
+
+    const match_date = date.format("YYYY-MM-DD");
+    const match_time = time.format("HH:mm");
+
+    const data: BroadcastFormData = {
+      match_date,
+      match_time,
+      sport,
+      league,
+      team_one: team1 ?? "",
+      team_two: team2 ?? "",
+      etc: note,
+    };
+
+    onSubmit(data);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+      <div className="bg-white rounded-xl shadow-lg w-full max-w-lg max-h-[90vh] overflow-y-auto p-8">
+        <h3 className="text-xl font-bold mb-6">
+          {mode === "edit" ? "중계 일정 수정" : "중계 일정 등록"}
+        </h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <label className="block mb-1">날짜</label>
+              <DatePicker
+                className="w-full"
+                value={date}
+                //다시 달력 눌렀을 때 초기화 후 달력 뜨는 문제 해결
+                onChange={(v) => {
+                  if (v) {
+                    setDate(v);
+                  }
+                }}
+                getPopupContainer={(trigger) =>
+                  trigger.parentNode as HTMLElement
+                }
+              />
+            </div>
+            <div className="flex-1">
+              <label className="block mb-1">시간</label>
+              <TimePicker
+                className="w-full"
+                format="HH:mm"
+                value={time}
+                onChange={(v) => setTime(v)}
+                getPopupContainer={(trigger) =>
+                  trigger.parentNode as HTMLElement
+                }
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block mb-1">종목</label>
+            <select
+              value={sport}
+              onChange={(e) => setSport(e.target.value)}
+              className="w-full border rounded px-3 py-2 hover:border-primary5 focus:border-primary5 focus:ring-1 focus:ring-primary1 focus:outline-none"
+            >
+              <option value="">종목 선택</option>
+              {Object.keys(sportsMap).map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block mb-1">리그</label>
+            <select
+              value={league}
+              onChange={(e) => setLeague(e.target.value)}
+              className="w-full border rounded px-3 py-2 hover:border-primary5 focus:border-primary5 focus:ring-1 focus:ring-primary1 focus:outline-none"
+            >
+              <option value="">리그 선택</option>
+              {Object.keys(sportsMap[sport] ?? {}).map((league) => (
+                <option key={league} value={league}>
+                  {league}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <label className="block mb-1">팀 1</label>
+              <input
+                className="w-full border rounded px-3 py-2 hover:border-primary5 focus:border-primary5 focus:ring-1 focus:ring-primary1 focus:outline-none"
+                value={team1 ?? ""}
+                onChange={(e) => setteam1(e.target.value)}
+              />
+            </div>
+
+            <div className="flex-1">
+              <label className="block mb-1">팀 2</label>
+              <input
+                className="w-full border rounded px-3 py-2 hover:border-primary5 focus:border-primary5 focus:ring-1 focus:ring-primary1 focus:outline-none"
+                value={team2 ?? ""}
+                onChange={(e) => setteam2(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block mb-1">기타</label>
+            <textarea
+              className="w-full border rounded px-3 py-2 hover:border-primary5 focus:border-primary5 focus:ring-1 focus:ring-primary1 focus:outline-none"
+              rows={3}
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 mt-4">
+            <button
+              type="button"
+              onClick={() => {
+                resetForm();
+                onClose();
+              }}
+              className="px-4 py-2 rounded bg-gray-100"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 rounded bg-primary5 text-white"
+            >
+              {mode === "edit" ? "수정" : "등록"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default BroadcastFormModal;

--- a/frontend/src/components/Search/SportPanel.tsx
+++ b/frontend/src/components/Search/SportPanel.tsx
@@ -1,81 +1,29 @@
-import { sportsMap } from "../../data/sports";
 import { useSportStore } from "../../stores/sportStore";
+import { sportsMap } from "../../data/sports";
+
+import SportSelect from "../Select/SportSelect";
+import LeagueSelect from "../Select/LeagueSelect";
+import TeamSelect from "../Select/TeamSelect";
 
 const SportPanel = () => {
   const { sport, league, teams, setSport, setLeague, toggleTeam } =
     useSportStore();
 
-  const leagues = sport ? Object.keys(sportsMap[sport]) : [];
   const teamList = sport && league ? sportsMap[sport][league] : [];
 
   return (
     <div className="p-4 flex flex-col gap-4">
       <div className="flex gap-4">
-        {/* 종목 */}
         <div className="flex-1">
-          <h3 className="text-sm font-semibold mb-2">종목</h3>
-          <select
-            onChange={(e) => setSport(e.target.value)}
-            value={sport}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-primary1"
-          >
-            <option value="">종목 선택</option>
-            {Object.keys(sportsMap).map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
+          <SportSelect value={sport} onChange={setSport} />
         </div>
-
-        {/* 리그 */}
         <div className="flex-1">
-          <h3 className="text-sm font-semibold mb-2">리그</h3>
-          <select
-            onChange={(e) => setLeague(e.target.value)}
-            value={league}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-primary1"
-            disabled={!sport}
-          >
-            <option value="">리그 선택</option>
-            {leagues.map((l) => (
-              <option key={l} value={l}>
-                {l}
-              </option>
-            ))}
-          </select>
+          <LeagueSelect sport={sport} value={league} onChange={setLeague} />
         </div>
       </div>
 
-      {/* 팀 선택 */}
       {league && (
-        <div>
-          <h3 className="text-sm font-semibold mb-2">팀</h3>
-          <div className="border p-2 max-h-40 overflow-y-auto">
-            <div className="grid grid-cols-2 divide-x divide-gray-300">
-              {[0, 1].map((col) => (
-                <div key={col} className="flex flex-col gap-2 px-2">
-                  {teamList
-                    .filter((_, idx) => idx % 2 === col)
-                    .map((team) => (
-                      <label
-                        key={team}
-                        className="flex justify-between items-center"
-                      >
-                        <span>{team}</span>
-                        <input
-                          type="checkbox"
-                          className="accent-primary1"
-                          checked={teams.includes(team)}
-                          onChange={() => toggleTeam(team)}
-                        />
-                      </label>
-                    ))}
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
+        <TeamSelect teams={teamList} selected={teams} toggle={toggleTeam} />
       )}
     </div>
   );

--- a/frontend/src/components/Select/LeagueSelect.tsx
+++ b/frontend/src/components/Select/LeagueSelect.tsx
@@ -1,0 +1,32 @@
+import { sportsMap } from "../../data/sports";
+
+interface LeagueSelectProps {
+  sport: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const LeagueSelect = ({ sport, value, onChange }: LeagueSelectProps) => {
+  const leagues = sport ? Object.keys(sportsMap[sport]) : [];
+
+  return (
+    <div>
+      <label className="text-sm font-semibold mb-2 block">리그</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={!sport}
+        className="w-full px-3 py-2 border border-gray-300 rounded-md text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-primary1"
+      >
+        <option value="">리그 선택</option>
+        {leagues.map((l) => (
+          <option key={l} value={l}>
+            {l}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default LeagueSelect;

--- a/frontend/src/components/Select/SportSelect.tsx
+++ b/frontend/src/components/Select/SportSelect.tsx
@@ -1,0 +1,28 @@
+import { sportsMap } from "../../data/sports";
+
+interface SportSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const SportSelect = ({ value, onChange }: SportSelectProps) => {
+  return (
+    <div>
+      <label className="text-sm font-semibold mb-2 block">종목</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full px-3 py-2 border border-gray-300 rounded-md text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-primary1"
+      >
+        <option value="">종목 선택</option>
+        {Object.keys(sportsMap).map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default SportSelect;

--- a/frontend/src/components/Select/TeamSelect.tsx
+++ b/frontend/src/components/Select/TeamSelect.tsx
@@ -1,0 +1,39 @@
+interface TeamSelectProps {
+  teams: string[];
+  selected: string[];
+  toggle: (team: string) => void;
+}
+
+const TeamSelect = ({ teams, selected, toggle }: TeamSelectProps) => {
+  return (
+    <div>
+      <label className="text-sm font-semibold mb-2 block">팀</label>
+      <div className="border p-2 max-h-40 overflow-y-auto">
+        <div className="grid grid-cols-2 divide-x divide-gray-300">
+          {[0, 1].map((col) => (
+            <div key={col} className="flex flex-col gap-2 px-2">
+              {teams
+                .filter((_, idx) => idx % 2 === col)
+                .map((team) => (
+                  <label
+                    key={team}
+                    className="flex justify-between items-center"
+                  >
+                    <span>{team}</span>
+                    <input
+                      type="checkbox"
+                      className="accent-primary1"
+                      checked={selected.includes(team)}
+                      onChange={() => toggle(team)}
+                    />
+                  </label>
+                ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TeamSelect;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,19 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import "antd/dist/reset.css";
+import { ConfigProvider } from "antd";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <ConfigProvider
+      theme={{
+        token: {
+          colorPrimary: "#66A648",
+        },
+      }}
+    >
+      <App />
+    </ConfigProvider>
   </StrictMode>
 );

--- a/frontend/src/stores/broadcastFormStore.ts
+++ b/frontend/src/stores/broadcastFormStore.ts
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+import { Dayjs } from "dayjs";
+
+interface BroadcastFormState {
+  date: Dayjs | null;
+  time: Dayjs | null;
+  sport: string;
+  league: string;
+  team1: string | null;
+  team2: string | null;
+  note: string;
+
+  setDate: (date: Dayjs | null) => void;
+  setTime: (time: Dayjs | null) => void;
+  setSport: (sport: string) => void;
+  setLeague: (league: string) => void;
+  setteam1: (team: string) => void;
+  setteam2: (team: string) => void;
+  setNote: (note: string) => void;
+
+  resetForm: () => void;
+  setInitialForm: (data: Partial<BroadcastFormState>) => void;
+}
+
+const useBroadcastFormStore = create<BroadcastFormState>((set) => ({
+  date: null,
+  time: null,
+  sport: "",
+  league: "",
+  team1: null,
+  team2: null,
+  note: "",
+
+  setDate: (date) => set({ date }),
+  setTime: (time) => set({ time }),
+  setSport: (sport) => set({ sport, league: "", team1: "", team2: "" }),
+  setLeague: (league) => set({ league, team1: "", team2: "" }),
+  setteam1: (team) => set({ team1: team }),
+  setteam2: (team) => set({ team2: team }),
+  setNote: (note) => set({ note }),
+  resetForm: () =>
+    set({
+      date: null,
+      time: null,
+      sport: "",
+      league: "",
+      team1: "",
+      team2: "",
+      note: "",
+    }),
+  setInitialForm: (data) => set({ ...data }),
+}));
+
+export default useBroadcastFormStore;

--- a/frontend/src/types/broadcastForm.ts
+++ b/frontend/src/types/broadcastForm.ts
@@ -1,0 +1,38 @@
+import { Dayjs } from "dayjs";
+
+export interface BroadcastFormData {
+  match_date: string;
+  match_time: string;
+  sport: string;
+  league: string;
+  team_one: string;
+  team_two: string;
+  etc?: string;
+}
+
+export interface BroadcastFormModalProps {
+  mode: "create" | "edit";
+  onSubmit: (data: BroadcastFormData) => void;
+  onClose: () => void;
+}
+
+export interface BroadcastFormState {
+  date: Dayjs | null;
+  time: Dayjs | null;
+  sport: string;
+  league: string;
+  team1: string | null;
+  team2: string | null;
+  note: string;
+
+  setDate: (date: Dayjs | null) => void;
+  setTime: (time: Dayjs | null) => void;
+  setSport: (sport: string) => void;
+  setLeague: (league: string) => void;
+  setteam1: (team: string | null) => void;
+  setteam2: (team: string | null) => void;
+  setNote: (note: string) => void;
+
+  resetForm: () => void;
+  setInitialForm: (data: Partial<BroadcastFormState>) => void;
+}


### PR DESCRIPTION
## 📎 관련 이슈
#48 


## 📌 PR 설명
중계 일정 등록 UI 구현


## ✅ 작업 내용
- [ ] Antd 컴포넌트 공통 색상 적용
- [ ] 중계 일정 등록 모달 구현 (우현님 식당 등록 UI 참고)
    - [ ] 날짜는 DatePicker, 시간은 TimePicker
    - [ ] 종목과 경기는 기존 경기 검색에 이용하던 드롭다운 메뉴


## 🧪 테스트 방법 (선택)
<img width="385" alt="스크린샷 2025-06-30 21 48 25" src="https://github.com/user-attachments/assets/cc7f822c-6e91-4e69-a6d7-e828a47f2c1e" />
<img width="384" alt="스크린샷 2025-06-30 21 48 33" src="https://github.com/user-attachments/assets/6b48fbad-a1f8-4be2-95e9-4211402e30af" />
<img width="384" alt="스크린샷 2025-06-30 21 48 36" src="https://github.com/user-attachments/assets/8d1ec629-b86f-47de-ac37-f226edd4c736" />
<img width="384" alt="스크린샷 2025-06-30 21 48 39" src="https://github.com/user-attachments/assets/bff64c4b-a286-4c2d-83c0-f94abb6f986a" />



## 💬 기타
- 수정은 추후 API 연결 후 진행 예정 