### PR TITLE
Fix: 중계 탭리스트 오늘 날짜를 중앙으로 배치(2)

### DIFF
--- a/frontend/src/components/Mypage/RestaurantManage/Broadcasts/TabLists.tsx
+++ b/frontend/src/components/Mypage/RestaurantManage/Broadcasts/TabLists.tsx
@@ -41,21 +41,23 @@ const TabList = () => {
 
   // 오늘 날짜를 중앙에 배치
   useEffect(() => {
-    if (tabRef.current) {
-      const targetItem = itemRefs.current.get(date);
+    const scrollContainer = tabRef.current;
+    const targetItem = itemRefs.current.get(date);
 
-      if (targetItem) {
-        const scrollContainer = tabRef.current;
-        const containerWidth = scrollContainer.clientWidth;
+    if (scrollContainer && targetItem) {
+      requestAnimationFrame(() => {
+        const scrollContainerWidth = scrollContainer.offsetWidth;
         const itemOffsetLeft = targetItem.offsetLeft;
+        const itemWidth = targetItem.offsetWidth;
 
-        const scrollToPosition = itemOffsetLeft - containerWidth / 2 - 100;
+        const itemCenter = itemOffsetLeft + itemWidth / 2;
+        const scrollTo = itemCenter - scrollContainerWidth * 1.5;
 
         scrollContainer.scrollTo({
-          left: scrollToPosition,
+          left: scrollTo,
           behavior: "smooth",
         });
-      }
+      });
     }
   }, [year, month, date]);
 


### PR DESCRIPTION
## 📎 관련 이슈
#24 


## 📌 PR 설명
중계 탭리스트 오늘 날짜를 중앙으로 배치


## ✅ 작업 내용
- [ ] 기능 구현
- [ ] UI 수정
- [x] 버그 수정


## 🧪 테스트 방법 (선택)


## 💬 기타
