### PR TITLE
Feat : 검색 결과 클릭 시 가게 상세보기로 이동 (#2)

### DIFF
--- a/frontend/src/components/Search/SearchResultItem.tsx
+++ b/frontend/src/components/Search/SearchResultItem.tsx
@@ -8,15 +8,16 @@ interface SearchResultItemProps {
     matchInfo: string;
     imgUrl: string;
   };
+  onClick?: () => void;
 }
 
-const SearchResultItem: FC<SearchResultItemProps> = ({ data }) => {
+const SearchResultItem: FC<SearchResultItemProps> = ({ data, onClick }) => {
   const { storeName, address, distance, matchInfo, imgUrl } = data;
 
   return (
     <div
       className="w-full hover:bg-primary4 transition-colors cursor-pointer border-b border-gray-200"
-      onClick={() => console.log(`클릭한 식당: ${storeName}`)}
+      onClick={onClick}
     >
       <div className="flex justify-between items-center px-4 py-3">
         <div className="flex flex-col">

--- a/frontend/src/components/Search/SearchResultList.tsx
+++ b/frontend/src/components/Search/SearchResultList.tsx
@@ -1,11 +1,17 @@
 import SearchResultItem from "./SearchResultItem";
 import { mockSearchResults } from "../../data/searchResult";
 import { useState } from "react";
+import { dummyRestaurantDetails } from "../../data/dummyRestaurantDetail";
+import type { RestaurantDetail } from "../../types/restaurant.types";
+import RestaurantDetailComponent from "../DetailStores/DetailStores";
 
 type SortType = "distance" | "date";
 
 const SearchResultList = () => {
   const [sortType, setSortType] = useState<SortType>("distance");
+  const [selectedDetail, setSelectedDetail] = useState<RestaurantDetail | null>(
+    null
+  );
 
   const sortedResults = [...mockSearchResults].sort((a, b) => {
     if (sortType === "distance") {
@@ -55,8 +61,25 @@ const SearchResultList = () => {
       {/* 검색 결과 리스트 */}
       <div>
         {sortedResults.map((item) => (
-          <SearchResultItem key={item.id} data={item} />
+          <SearchResultItem
+            key={item.id}
+            data={item}
+            onClick={() => {
+              const detail = dummyRestaurantDetails.find(
+                (d) => d.id === item.id
+              );
+              if (detail) setSelectedDetail(detail);
+              else alert("상세 mock 데이터를 찾을 수 없습니다.");
+            }}
+          />
         ))}
+
+        {selectedDetail && (
+          <RestaurantDetailComponent
+            detail={selectedDetail}
+            onClose={() => setSelectedDetail(null)}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/data/dummyRestaurantDetail.ts
+++ b/frontend/src/data/dummyRestaurantDetail.ts
@@ -106,4 +106,52 @@ export const dummyRestaurantDetails: RestaurantDetail[] = [
       },
     ],
   },
+  {
+    id: 5,
+    store_name: "더치킨 명동점",
+    address: "서울 중구 명동10길 21",
+    phone: "051-555-7777",
+    opening_hours: "매일 18:00 ~ 03:00",
+    menus: ["나쵸", "핫도그", "버드와이저", "하이네켄"],
+    type: "펍/호프",
+    img_list: [
+      "https://images.pexels.com/photos/1395967/pexels-photo-1395967.jpeg?auto=compress&w=400&q=80",
+    ],
+    description: "바다 보며 보는 축구는 또 다른 재미! 외국인 손님도 많아요.",
+    broadcasts: [
+      {
+        match_date: "2025-07-06",
+        match_time: "22:00",
+        sport: "축구",
+        league: "유로 2024",
+        team_one: "프랑스",
+        team_two: "독일",
+        etc: "4강전",
+      },
+    ],
+  },
+  {
+    id: 6,
+    store_name: "레드풋볼 강남점",
+    address: "서울 강남구 역삼로 111",
+    phone: "051-555-7777",
+    opening_hours: "매일 18:00 ~ 03:00",
+    menus: ["나쵸", "핫도그", "버드와이저", "하이네켄"],
+    type: "스포츠 바",
+    img_list: [
+      "https://images.pexels.com/photos/1395967/pexels-photo-1395967.jpeg?auto=compress&w=400&q=80",
+    ],
+    description: "바다 보며 보는 축구는 또 다른 재미! 외국인 손님도 많아요.",
+    broadcasts: [
+      {
+        match_date: "2025-07-06",
+        match_time: "22:00",
+        sport: "축구",
+        league: "유로 2024",
+        team_one: "프랑스",
+        team_two: "독일",
+        etc: "4강전",
+      },
+    ],
+  },
 ];

--- a/frontend/src/data/searchResult.ts
+++ b/frontend/src/data/searchResult.ts
@@ -1,6 +1,6 @@
 export const mockSearchResults = [
   {
-    id: 1,
+    id: 6,
     storeName: "레드풋볼 강남점",
     address: "서울 강남구 역삼로 111",
     imgUrl: "https://picsum.photos/120/90",
@@ -8,7 +8,7 @@ export const mockSearchResults = [
     matchInfo: "7/27 리버풀 vs 밀란",
   },
   {
-    id: 2,
+    id: 5,
     storeName: "더치킨 명동점",
     address: "서울 중구 명동10길 21",
     imgUrl: "https://picsum.photos/120/90",


### PR DESCRIPTION
## 📎 관련 이슈
`#2` 


## 📌 PR 설명
검색 결과 리스트 클릭 시 식당 상세보기로 이동 


## ✅ 작업 내용
- [ ] 검색 결과 아이템 클릭 시 상세 패널 출력 기능 구현
- [ ]  mock 데이터 기반으로 상세 정보 매칭 및 조건부 렌더링 적용

## 🧪 테스트 방법 (선택)

<img width="218" alt="스크린샷 2025-07-01 13 56 36" src="https://github.com/user-attachments/assets/5b257892-e525-432c-90ff-69b014a65488" />


## 💬 기타
추가로 공유할 내용이나 주의 사항
