### PR TITLE
Fe/#60/favorites

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,19 @@
+import { useEffect } from "react";
 import Home from "./pages/Home";
+import useAuthStore from "./stores/authStore";
+import useFavoriteStore from "./stores/favoriteStore";
 
 function App() {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  const resetFavorites = useFavoriteStore((state) => state.resetFavorites);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      resetFavorites();
+    }
+    // 로그인 시 fetchFavorites() 등도 가능
+  }, [isLoggedIn, resetFavorites]);
+
   return (
     <main className="min-h-screen bg-gray-50 font-sans relative">
       <Home />

--- a/frontend/src/api/favorite.api.ts
+++ b/frontend/src/api/favorite.api.ts
@@ -1,0 +1,12 @@
+import { requestHandler } from "./http";
+
+// 즐겨찾기 목록 조회
+export const getFavorites = () => requestHandler("get", "/favorites");
+
+// 즐겨찾기 추가 (명세서에 따라 post 또는 get)
+export const addFavorite = (store_id: number) =>
+  requestHandler("post", `/favorites/${store_id}`);
+
+// 즐겨찾기 삭제
+export const removeFavorite = (store_id: number) =>
+  requestHandler("delete", `/favorites/${store_id}`);

--- a/frontend/src/components/Map/PlayceMap.tsx
+++ b/frontend/src/components/Map/PlayceMap.tsx
@@ -3,7 +3,7 @@ import { Map } from "react-kakao-maps-sdk";
 import useMapStore from "../../stores/mapStore";
 import PlayceMapMarker from "./PlayceMapMarker";
 import PlayceModal from "./PlayceModal";
-import RestaurantDetailComponent from "../RestaurantDetail/RestaurantDetail.tsx";
+import RestaurantDetailComponent from "../RestaurantDetail/RestaurantDetail";
 import { getStoreDetail } from "../../api/restaurant.api"; // 상세조회 API 함수
 import type {
   RestaurantBasic,
@@ -21,9 +21,10 @@ const PlayceMap: React.FC = () => {
   } = useMapStore();
 
   const [isDetailOpen, setIsDetailOpen] = useState(false);
-  const [selectedDetail, setSelectedDetail] = useState<RestaurantDetail | null>(
-    null
-  );
+  const [selectedDetail, setSelectedDetail] = useState<{
+    storeId: number;
+    detail: RestaurantDetail;
+  } | null>(null);
 
   const mapRef = useRef<kakao.maps.Map>(null);
 
@@ -34,12 +35,12 @@ const PlayceMap: React.FC = () => {
     return { lat: center.getLat(), lng: center.getLng() };
   };
 
-  // 상세조회 API 연동
+  // 상세조회 API 연동 (storeId와 detail을 함께 저장)
   const handleDetailClick = async (restaurant: RestaurantBasic) => {
     try {
       const res = await getStoreDetail(restaurant.store_id);
       if (res.success && res.data) {
-        setSelectedDetail(res.data);
+        setSelectedDetail({ storeId: restaurant.store_id, detail: res.data });
         setIsDetailOpen(true);
       } else {
         alert("상세 정보를 찾을 수 없습니다.");
@@ -80,7 +81,8 @@ const PlayceMap: React.FC = () => {
       {isDetailOpen && selectedDetail && (
         <div className="fixed left-0 top-0 h-full w-[370px] z-[9999] shadow-2xl bg-white">
           <RestaurantDetailComponent
-            detail={selectedDetail}
+            detail={selectedDetail.detail}
+            storeId={selectedDetail.storeId}
             onClose={() => {
               setIsDetailOpen(false);
               setSelectedDetail(null);

--- a/frontend/src/components/Map/PlayceModal.tsx
+++ b/frontend/src/components/Map/PlayceModal.tsx
@@ -1,8 +1,10 @@
 import type { RestaurantBasic } from "../../types/restaurant.types";
 import { CustomOverlayMap } from "react-kakao-maps-sdk";
 import { FiStar, FiMapPin, FiX } from "react-icons/fi";
+import { FaStar } from "react-icons/fa";
 import Button from "../Common/Button";
 import useFavoriteStore from "../../stores/favoriteStore";
+import useAuthStore from "../../stores/authStore";
 
 const defaultImage = "https://placehold.co/300x200?text=No+Image";
 
@@ -17,14 +19,22 @@ const PlayceModal = ({
   onDetailClick,
   onClose,
 }: PlayceModalProps) => {
-  const { favoriteIds, addFavorite, removeFavorite } = useFavoriteStore();
-  const isFavorite = favoriteIds.includes(restaurant.store_id);
+  const { favorites, addFavorite, removeFavorite } = useFavoriteStore();
+  const isFavorite = favorites.some(
+    (fav) => fav.store_id === restaurant.store_id
+  );
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
-  const handleToggleFavorite = () => {
+  const handleToggleFavorite = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!isLoggedIn) {
+      alert("로그인 후 이용할 수 있는 기능입니다.");
+      return;
+    }
     if (isFavorite) {
-      removeFavorite(restaurant.store_id);
+      await removeFavorite(restaurant.store_id);
     } else {
-      addFavorite(restaurant.store_id);
+      await addFavorite(restaurant.store_id);
     }
   };
 
@@ -42,25 +52,25 @@ const PlayceModal = ({
             className="w-full h-full object-cover"
           />
           {/* 좌상단: 저장(즐겨찾기) 버튼 */}
-          <div className="absolute left-2 top-2 flex gap-2 z-10">
-            <button
-              onMouseDown={(e) => e.stopPropagation()}
-              onClick={handleToggleFavorite}
-              className="bg-white/80 rounded-full p-2 shadow hover:bg-primary3 transition flex items-center justify-center"
-              aria-label={isFavorite ? "즐겨찾기 해제" : "즐겨찾기 추가"}
-            >
-              {isFavorite ? (
-                <FiStar className="text-yellow-400 text-lg" />
-              ) : (
-                <FiStar className="text-primary5 text-lg" />
-              )}
-            </button>
-          </div>
+          <button
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={handleToggleFavorite}
+            className="absolute left-2 top-2 bg-white/80 rounded-full p-2 shadow flex items-center justify-center transition"
+            aria-label={isFavorite ? "즐겨찾기 해제" : "즐겨찾기 추가"}
+            style={{ border: "none" }}
+          >
+            {isFavorite ? (
+              <FaStar className="text-yellow-400 text-lg" />
+            ) : (
+              <FiStar className="text-primary5 text-lg" />
+            )}
+          </button>
           {/* 우상단: 닫기 버튼 */}
           <button
             onClick={onClose}
-            className="absolute right-2 top-2 z-10 bg-white/80 rounded-full p-2 shadow hover:bg-primary3 transition flex items-center justify-center"
+            className="absolute right-2 top-2 bg-white/80 rounded-full p-2 shadow flex items-center justify-center transition"
             aria-label="닫기"
+            style={{ border: "none" }}
           >
             <FiX className="text-primary5 text-lg" />
           </button>

--- a/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
@@ -13,30 +13,37 @@ import type { RestaurantDetail } from "../../types/restaurant.types";
 import Button from "../Common/Button";
 import classNames from "classnames";
 import useFavoriteStore from "../../stores/favoriteStore";
+import useAuthStore from "../../stores/authStore";
 
 const TABS = ["홈", "메뉴", "중계"] as const;
 type Tab = (typeof TABS)[number];
 
 interface RestaurantDetailComponentProps {
   detail: RestaurantDetail;
+  storeId: number;
   onClose?: () => void;
 }
 
 export default function RestaurantDetailComponent({
   detail,
+  storeId,
   onClose,
 }: RestaurantDetailComponentProps) {
   const [currentTab, setCurrentTab] = useState<Tab>("홈");
 
-  // 즐겨찾기 글로벌 상태 사용
-  const { favoriteIds, addFavorite, removeFavorite } = useFavoriteStore();
-  const isFavorite = favoriteIds.includes(detail.id);
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  const { favorites, addFavorite, removeFavorite } = useFavoriteStore();
+  const isFavorite = favorites.some((fav) => fav.store_id === storeId);
 
-  const handleToggleFavorite = () => {
+  const handleToggleFavorite = async () => {
+    if (!isLoggedIn) {
+      alert("로그인 후 즐겨찾기 기능을 이용해보세요.");
+      return;
+    }
     if (isFavorite) {
-      removeFavorite(detail.id);
+      await removeFavorite(storeId);
     } else {
-      addFavorite(detail.id);
+      await addFavorite(storeId);
     }
   };
 

--- a/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
@@ -37,7 +37,7 @@ export default function RestaurantDetailComponent({
 
   const handleToggleFavorite = async () => {
     if (!isLoggedIn) {
-      alert("로그인 후 즐겨찾기 기능을 이용해보세요.");
+      alert("로그인 후 이용할 수 있는 기능입니다.");
       return;
     }
     if (isFavorite) {

--- a/frontend/src/stores/favoriteStore.ts
+++ b/frontend/src/stores/favoriteStore.ts
@@ -1,26 +1,32 @@
-// stores/favoriteStore.ts
 import { create } from "zustand";
+import { getFavorites, addFavorite, removeFavorite } from "../api/favorite.api";
+import type { RestaurantBasic } from "../types/restaurant.types";
 
 interface FavoriteStoreState {
-  favoriteIds: number[];
-  setFavorites: (ids: number[]) => void;
-  addFavorite: (id: number) => void;
-  removeFavorite: (id: number) => void;
+  favorites: RestaurantBasic[];
+  fetchFavorites: () => Promise<void>;
+  addFavorite: (store_id: number) => Promise<void>;
+  removeFavorite: (store_id: number) => Promise<void>;
 }
 
-const useFavoriteStore = create<FavoriteStoreState>((set) => ({
-  favoriteIds: [1, 2, 3, 4, 5],
-  setFavorites: (ids) => set({ favoriteIds: ids }),
-  addFavorite: (id) =>
-    set((state) => ({
-      favoriteIds: state.favoriteIds.includes(id)
-        ? state.favoriteIds
-        : [...state.favoriteIds, id],
-    })),
-  removeFavorite: (id) =>
-    set((state) => ({
-      favoriteIds: state.favoriteIds.filter((fid) => fid !== id),
-    })),
+const useFavoriteStore = create<FavoriteStoreState>((set, get) => ({
+  favorites: [],
+  fetchFavorites: async () => {
+    try {
+      const res = await getFavorites();
+      set({ favorites: res.data.stores || [] });
+    } catch {
+      set({ favorites: [] }); // 에러 시 빈 배열로
+    }
+  },
+  addFavorite: async (store_id) => {
+    await addFavorite(store_id);
+    await get().fetchFavorites();
+  },
+  removeFavorite: async (store_id) => {
+    await removeFavorite(store_id);
+    await get().fetchFavorites();
+  },
 }));
 
 export default useFavoriteStore;

--- a/frontend/src/stores/favoriteStore.ts
+++ b/frontend/src/stores/favoriteStore.ts
@@ -9,14 +9,16 @@ interface FavoriteStoreState {
   removeFavorite: (store_id: number) => Promise<void>;
 }
 
-const useFavoriteStore = create<FavoriteStoreState>((set, get) => ({
+const useFavoriteStore = create<
+  FavoriteStoreState & { resetFavorites: () => void }
+>((set, get) => ({
   favorites: [],
   fetchFavorites: async () => {
     try {
       const res = await getFavorites();
       set({ favorites: res.data.stores || [] });
     } catch {
-      set({ favorites: [] }); // 에러 시 빈 배열로
+      set({ favorites: [] });
     }
   },
   addFavorite: async (store_id) => {
@@ -27,6 +29,7 @@ const useFavoriteStore = create<FavoriteStoreState>((set, get) => ({
     await removeFavorite(store_id);
     await get().fetchFavorites();
   },
+  resetFavorites: () => set({ favorites: [] }), // 추가!
 }));
 
 export default useFavoriteStore;


### PR DESCRIPTION
## 📎 관련 이슈
#73 


## 📌 PR 설명

- 즐겨찾기 기능을 더미데이터 기반에서 API 연동 구조로 전환하였습니다.

- 상세보기, 지도 마커, 마이페이지 등 다양한 진입점에서 즐겨찾기 추가/삭제가 일관되게 동작하도록 구현했습니다.

- 상세조회 API 응답에 store_id가 없는 문제를 해결하기 위해, 상위 컴포넌트에서 storeId를 별도 prop으로 전달하도록 구조를 개선했습니다.

- 로그인하지 않은 상태에서 즐겨찾기 버튼 클릭 시 로그인 안내 메시지가 노출됩니다.

- 즐겨찾기 상태에 따라 꽉 찬 별/빈 별 UI가 일관되게 적용됩니다.

- 로그아웃시 상태초기화 되게 App.tsx에 작성했습니다.


## ✅ 작업 내용
- [x] 기능 구현
- [x] UI 수정
- [ ] 버그 수정


## 🧪 테스트 방법 (선택)
어떻게 테스트했는지, 테스트할 방법이 있다면 적어주세요.


## 💬 기타
추가로 공유할 내용이나 주의 사항

![스크린샷 2025-07-06 221825](https://github.com/user-attachments/assets/73c0922c-dfdd-472f-a095-41eb0d4b9f0b)

