### PR TITLE
Fe/#89/detail stores

### DIFF
--- a/frontend/src/components/FavoriteSidebar/FavoriteSidebar.tsx
+++ b/frontend/src/components/FavoriteSidebar/FavoriteSidebar.tsx
@@ -4,19 +4,12 @@ import useFavoriteStore from "../../stores/favoriteStore";
 import useAuthStore from "../../stores/authStore";
 import RestaurantCardList from "../RestaurantCardList/RestaurantCardList";
 import RestaurantDetailComponent from "../RestaurantDetail/RestaurantDetail.tsx";
-import type { RestaurantDetail } from "../../types/restaurant.types";
-import { getStoreDetail } from "../../api/restaurant.api";
 
 export default function FavoriteSidebar() {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const { favorites, fetchFavorites, removeFavorite } = useFavoriteStore();
   const [expanded, setExpanded] = useState(false);
-
-  // storeId와 detail을 함께 관리
-  const [selectedDetail, setSelectedDetail] = useState<{
-    storeId: number;
-    detail: RestaurantDetail;
-  } | null>(null);
+  const [selectedStoreId, setSelectedStoreId] = useState<number | null>(null);
 
   useEffect(() => {
     if (isLoggedIn) {
@@ -26,18 +19,9 @@ export default function FavoriteSidebar() {
 
   const visibleFavorites = expanded ? favorites : favorites.slice(0, 3);
 
-  // 상세보기 버튼 클릭 시 storeId와 detail을 함께 저장
-  const handleDetail = async (store_id: number) => {
-    try {
-      const res = await getStoreDetail(store_id);
-      if (res.success && res.data) {
-        setSelectedDetail({ storeId: store_id, detail: res.data });
-      } else {
-        alert("상세 정보를 찾을 수 없습니다.");
-      }
-    } catch {
-      alert("상세 정보를 불러오지 못했습니다.");
-    }
+  // 상세보기 버튼 클릭 시 storeId만 저장
+  const handleDetail = (store_id: number) => {
+    setSelectedStoreId(store_id);
   };
 
   return (
@@ -68,11 +52,10 @@ export default function FavoriteSidebar() {
             compact
             onDetail={handleDetail}
           />
-          {selectedDetail && (
+          {selectedStoreId !== null && (
             <RestaurantDetailComponent
-              detail={selectedDetail.detail}
-              storeId={selectedDetail.storeId}
-              onClose={() => setSelectedDetail(null)}
+              storeId={selectedStoreId}
+              onClose={() => setSelectedStoreId(null)}
             />
           )}
         </>

--- a/frontend/src/components/Map/PlayceMap.tsx
+++ b/frontend/src/components/Map/PlayceMap.tsx
@@ -4,11 +4,7 @@ import useMapStore from "../../stores/mapStore";
 import PlayceMapMarker from "./PlayceMapMarker";
 import PlayceModal from "./PlayceModal";
 import RestaurantDetailComponent from "../RestaurantDetail/RestaurantDetail";
-import { getStoreDetail } from "../../api/restaurant.api"; // 상세조회 API 함수
-import type {
-  RestaurantBasic,
-  RestaurantDetail,
-} from "../../types/restaurant.types";
+import type { RestaurantBasic } from "../../types/restaurant.types";
 
 const PlayceMap: React.FC = () => {
   const {
@@ -21,10 +17,7 @@ const PlayceMap: React.FC = () => {
   } = useMapStore();
 
   const [isDetailOpen, setIsDetailOpen] = useState(false);
-  const [selectedDetail, setSelectedDetail] = useState<{
-    storeId: number;
-    detail: RestaurantDetail;
-  } | null>(null);
+  const [selectedStoreId, setSelectedStoreId] = useState<number | null>(null);
 
   const mapRef = useRef<kakao.maps.Map>(null);
 
@@ -35,19 +28,10 @@ const PlayceMap: React.FC = () => {
     return { lat: center.getLat(), lng: center.getLng() };
   };
 
-  // 상세조회 API 연동 (storeId와 detail을 함께 저장)
-  const handleDetailClick = async (restaurant: RestaurantBasic) => {
-    try {
-      const res = await getStoreDetail(restaurant.store_id);
-      if (res.success && res.data) {
-        setSelectedDetail({ storeId: restaurant.store_id, detail: res.data });
-        setIsDetailOpen(true);
-      } else {
-        alert("상세 정보를 찾을 수 없습니다.");
-      }
-    } catch {
-      alert("상세 정보를 불러오지 못했습니다.");
-    }
+  // 상세보기 오픈 시 storeId만 저장
+  const handleDetailClick = (restaurant: RestaurantBasic) => {
+    setSelectedStoreId(restaurant.store_id);
+    setIsDetailOpen(true);
   };
 
   return (
@@ -78,14 +62,13 @@ const PlayceMap: React.FC = () => {
           />
         )}
       </Map>
-      {isDetailOpen && selectedDetail && (
+      {isDetailOpen && selectedStoreId && (
         <div className="fixed left-0 top-0 h-full w-[370px] z-[9999] shadow-2xl bg-white">
           <RestaurantDetailComponent
-            detail={selectedDetail.detail}
-            storeId={selectedDetail.storeId}
+            storeId={selectedStoreId}
             onClose={() => {
               setIsDetailOpen(false);
-              setSelectedDetail(null);
+              setSelectedStoreId(null);
             }}
           />
         </div>

--- a/frontend/src/components/Mypage/FavoriteList.tsx
+++ b/frontend/src/components/Mypage/FavoriteList.tsx
@@ -1,10 +1,8 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { FaTimes } from "react-icons/fa";
 import useFavoriteStore from "../../stores/favoriteStore";
 import RestaurantCardList from "../RestaurantCardList/RestaurantCardList";
 import RestaurantDetailComponent from "../RestaurantDetail/RestaurantDetail";
-import type { RestaurantDetail } from "../../types/restaurant.types";
-import { getStoreDetail } from "../../api/restaurant.api";
 
 interface FavoriteListProps {
   onClose: () => void;
@@ -12,28 +10,15 @@ interface FavoriteListProps {
 
 const FavoriteList = ({ onClose }: FavoriteListProps) => {
   const { favorites, fetchFavorites, removeFavorite } = useFavoriteStore();
-  // storeId와 detail을 함께 관리
-  const [selectedDetail, setSelectedDetail] = useState<{
-    storeId: number;
-    detail: RestaurantDetail;
-  } | null>(null);
+  const [selectedStoreId, setSelectedStoreId] = useState<number | null>(null);
 
   useEffect(() => {
     fetchFavorites();
   }, [fetchFavorites]);
 
-  // 상세보기 버튼 클릭 시 storeId와 detail을 함께 저장
-  const handleDetail = async (store_id: number) => {
-    try {
-      const res = await getStoreDetail(store_id);
-      if (res.success && res.data) {
-        setSelectedDetail({ storeId: store_id, detail: res.data });
-      } else {
-        alert("상세 정보를 찾을 수 없습니다.");
-      }
-    } catch {
-      alert("상세 정보를 불러오지 못했습니다.");
-    }
+  // 상세보기 버튼 클릭 시 storeId만 저장
+  const handleDetail = (store_id: number) => {
+    setSelectedStoreId(store_id);
   };
 
   return (
@@ -57,11 +42,10 @@ const FavoriteList = ({ onClose }: FavoriteListProps) => {
         onDetail={handleDetail}
       />
       {/* 상세보기 모달/사이드바 */}
-      {selectedDetail && (
+      {selectedStoreId !== null && (
         <RestaurantDetailComponent
-          detail={selectedDetail.detail}
-          storeId={selectedDetail.storeId}
-          onClose={() => setSelectedDetail(null)}
+          storeId={selectedStoreId}
+          onClose={() => setSelectedStoreId(null)}
         />
       )}
     </section>

--- a/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
@@ -1,23 +1,17 @@
 import { useState, useEffect } from "react";
-import {
-  FiStar,
-  FiMapPin,
-  FiClock,
-  FiPhone,
-  FiFileText,
-  FiX,
-  FiTv,
-} from "react-icons/fi";
-import { FaUtensils, FaStar } from "react-icons/fa";
 import type { RestaurantDetail } from "../../types/restaurant.types";
-import Button from "../Common/Button";
-import classNames from "classnames";
 import useFavoriteStore from "../../stores/favoriteStore";
 import useAuthStore from "../../stores/authStore";
 import { getStoreDetail } from "../../api/restaurant.api";
+import RestaurantDetailHeader from "./RestaurantDetailHeader";
+import RestaurantDetailImageSection from "./RestaurantDetailImageSection";
+import RestaurantDetailTabs from "./RestaurantDetailTabs";
+import RestaurantDetailHomeTab from "./RestaurantDetailHomeTab";
+import RestaurantDetailMenuTab from "./RestaurantDetailMenuTab";
+import RestaurantDetailBroadcastTab from "./RestaurantDetailBroadcastTab";
+import RestaurantDetailPhotoTab from "./RestaurantDetailPhotoTab";
 
-const TABS = ["홈", "메뉴", "중계"] as const;
-type Tab = (typeof TABS)[number];
+type Tab = "홈" | "메뉴" | "사진" | "중계";
 
 interface RestaurantDetailComponentProps {
   storeId: number;
@@ -86,195 +80,26 @@ export default function RestaurantDetailComponent({
 
   return (
     <aside className="fixed left-0 top-0 h-full w-[430px] z-[100] bg-white shadow-2xl border-r border-gray-100 flex flex-col font-pretendard">
-      {/* 헤더 */}
-      <div className="h-12 flex items-center pl-6 border-b border-gray-100">
-        <button
-          className="text-2xl font-bold tracking-tight text-primary5 font-pretendard focus:outline-none"
-          onClick={onClose}
-          aria-label="상세보기 닫기"
-          type="button"
-        >
-          Playce
-        </button>
-      </div>
-
-      {/* 이미지 */}
-      <div className="w-full h-56 bg-gradient-to-tr via-white to-orange-50 flex items-center justify-center relative">
-        {detail.img_urls?.[0] ? (
-          <img
-            src={detail.img_urls[0]}
-            alt={detail.store_name}
-            className="w-full h-full object-cover rounded-b-xl"
-          />
-        ) : (
-          <span className="text-gray-400">이미지 없음</span>
-        )}
-        {/* 저장/공유 버튼 */}
-        <div className="absolute left-6 top-6 flex gap-3 z-10">
-          <button
-            onClick={handleToggleFavorite}
-            className="bg-white/90 rounded-full p-2 shadow hover:bg-orange-50 transition"
-            aria-label={isFavorite ? "즐겨찾기 해제" : "즐겨찾기 추가"}
-          >
-            {isFavorite ? (
-              <FaStar className="text-yellow-400 text-lg" />
-            ) : (
-              <FiStar className="text-primary5 text-lg" />
-            )}
-          </button>
-        </div>
-        {/* 닫기(X) 버튼 */}
-        {onClose && (
-          <button
-            onClick={onClose}
-            className="absolute top-6 right-6 bg-white/90 rounded-full p-2 shadow hover:bg-orange-50 transition z-20"
-            aria-label="상세보기 닫기"
-          >
-            <FiX className="text-primary5 text-lg" />
-          </button>
-        )}
-      </div>
-
-      {/* 탭 메뉴 */}
-      <div className="flex border-b border-gray-200 bg-white sticky top-0 z-10">
-        {TABS.map((tab) => (
-          <Button
-            key={tab}
-            scheme="tab"
-            className={classNames(
-              "flex-1 py-3 flex items-center justify-center gap-1 transition-all",
-              currentTab === tab && "text-primary5 border-primary5 bg-white"
-            )}
-            onClick={() => setCurrentTab(tab)}
-          >
-            {tab === "메뉴" && <FaUtensils className="text-base" />}
-            {tab === "중계" && <FiTv className="text-base" />}
-            {tab}
-          </Button>
-        ))}
-      </div>
-
-      {/* 탭 내용 */}
+      <RestaurantDetailHeader />
+      <RestaurantDetailImageSection
+        detail={detail}
+        isFavorite={isFavorite}
+        onToggleFavorite={handleToggleFavorite}
+        onClose={onClose}
+      />
+      <RestaurantDetailTabs
+        currentTab={currentTab}
+        setCurrentTab={setCurrentTab}
+      />
       <div className="flex-1 p-6 text-base overflow-y-auto">
-        {/* 홈 탭 */}
-        {currentTab === "홈" && (
-          <div className="flex flex-col gap-4">
-            {/* 내 가게일 때만 표시되는 뱃지 */}
-            {detail.is_owner && (
-              <div className="flex items-center gap-2 mb-2">
-                <span className="px-2 py-1 bg-primary3 text-primary5 rounded text-xs font-bold">
-                  내 가게
-                </span>
-              </div>
-            )}
-            <h2 className="text-2xl font-bold mb-2">{detail.store_name}</h2>
-            <p className="mb-2 text-gray-700">{detail.description}</p>
-            <div className="flex items-center gap-2">
-              <FiMapPin className="text-xl" />
-              <span>{detail.address}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <FiClock className="text-xl" />
-              <span>{detail.opening_hours}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <FiPhone className="text-xl" />
-              <span>{detail.phone}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <FiFileText className="text-xl" />
-              <span>{detail.type}</span>
-            </div>
-          </div>
-        )}
-
-        {/* 메뉴 탭 */}
-        {currentTab === "메뉴" && (
-          <ul className="grid grid-cols-1 gap-3">
-            {(() => {
-              let menus: string[] = [];
-              if (typeof detail.menus === "string") {
-                menus = detail.menus
-                  .split(",")
-                  .map((m) => m.trim())
-                  .filter(Boolean);
-              } else if (Array.isArray(detail.menus)) {
-                menus = detail.menus;
-              }
-
-              return menus.length > 0 ? (
-                menus.map((menu, idx) => (
-                  <li
-                    key={idx}
-                    className={`flex items-center gap-3 px-5 py-3 ${
-                      idx !== menus.length - 1 ? "border-b border-gray-200" : ""
-                    }`}
-                  >
-                    <FaUtensils className="text-primary1 text-lg" />
-                    <span className="font-medium text-gray-700">{menu}</span>
-                  </li>
-                ))
-              ) : (
-                <li className="py-3 text-gray-400 text-center">
-                  메뉴 정보 없음
-                </li>
-              );
-            })()}
-          </ul>
-        )}
-
-        {/* 중계 탭 */}
+        {currentTab === "홈" && <RestaurantDetailHomeTab detail={detail} />}
+        {currentTab === "메뉴" && <RestaurantDetailMenuTab detail={detail} />}
+        {currentTab === "사진" && <RestaurantDetailPhotoTab detail={detail} />}
         {currentTab === "중계" && (
-          <div>
-            <ul className="flex flex-col gap-4">
-              {detail.broadcasts.length > 0 ? (
-                detail.broadcasts.map((b, idx) => (
-                  <li
-                    key={idx}
-                    className="rounded-xl p-4 flex flex-col gap-1 border border-primary2"
-                  >
-                    <div className="flex items-center gap-2 mb-1">
-                      <FiTv className="text-primary5" />
-                      <span className="font-semibold">
-                        {b.league} {b.sport}
-                      </span>
-                      <span className="ml-auto text-xs text-gray-400">
-                        {b.match_date} {b.match_time}
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-2 text-base font-bold text-gray-800">
-                      {b.team_one}
-                      <span className="mx-1 text-primary5">vs</span>
-                      {b.team_two}
-                      {b.etc && (
-                        <span className="ml-2 text-xs bg-primary3 text-primary5 rounded px-2 py-0.5">
-                          {b.etc}
-                        </span>
-                      )}
-                    </div>
-                  </li>
-                ))
-              ) : (
-                <li className="py-6 text-gray-400 text-center">
-                  예정된 중계가 없습니다.
-                </li>
-              )}
-            </ul>
-            {/* 내 가게일 때만 하단에 일정 관리 버튼 노출 */}
-            {detail.is_owner && (
-              <div className="mt-6 flex justify-end">
-                <Button
-                  scheme="primary"
-                  onClick={() => {
-                    // TODO: 중계일정 관리 기능 구현
-                    alert("중계일정 관리 기능을 여기에 구현하세요!");
-                  }}
-                >
-                  중계 관리
-                </Button>
-              </div>
-            )}
-          </div>
+          <RestaurantDetailBroadcastTab
+            detail={detail}
+            onManage={() => alert("중계일정 관리 기능을 여기에 구현하세요!")}
+          />
         )}
       </div>
     </aside>

--- a/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
@@ -180,40 +180,56 @@ export default function RestaurantDetailComponent({
 
         {/* 중계 탭 */}
         {currentTab === "중계" && (
-          <ul className="flex flex-col gap-4">
-            {detail.broadcasts.length > 0 ? (
-              detail.broadcasts.map((b, idx) => (
-                <li
-                  key={idx}
-                  className="rounded-xl p-4 flex flex-col gap-1 border border-primary2"
-                >
-                  <div className="flex items-center gap-2 mb-1">
-                    <FiTv className="text-primary5" />
-                    <span className="font-semibold">
-                      {b.league} {b.sport}
-                    </span>
-                    <span className="ml-auto text-xs text-gray-400">
-                      {b.match_date} {b.match_time}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2 text-base font-bold text-gray-800">
-                    {b.team_one}
-                    <span className="mx-1 text-primary5">vs</span>
-                    {b.team_two}
-                    {b.etc && (
-                      <span className="ml-2 text-xs bg-primary3 text-primary5 rounded px-2 py-0.5">
-                        {b.etc}
+          <div>
+            <ul className="flex flex-col gap-4">
+              {detail.broadcasts.length > 0 ? (
+                detail.broadcasts.map((b, idx) => (
+                  <li
+                    key={idx}
+                    className="rounded-xl p-4 flex flex-col gap-1 border border-primary2"
+                  >
+                    <div className="flex items-center gap-2 mb-1">
+                      <FiTv className="text-primary5" />
+                      <span className="font-semibold">
+                        {b.league} {b.sport}
                       </span>
-                    )}
-                  </div>
+                      <span className="ml-auto text-xs text-gray-400">
+                        {b.match_date} {b.match_time}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-base font-bold text-gray-800">
+                      {b.team_one}
+                      <span className="mx-1 text-primary5">vs</span>
+                      {b.team_two}
+                      {b.etc && (
+                        <span className="ml-2 text-xs bg-primary3 text-primary5 rounded px-2 py-0.5">
+                          {b.etc}
+                        </span>
+                      )}
+                    </div>
+                  </li>
+                ))
+              ) : (
+                <li className="py-6 text-gray-400 text-center">
+                  예정된 중계가 없습니다.
                 </li>
-              ))
-            ) : (
-              <li className="py-6 text-gray-400 text-center">
-                예정된 중계가 없습니다.
-              </li>
+              )}
+            </ul>
+            {/* 내 가게일 때만 하단에 일정 관리 버튼 노출 */}
+            {detail.is_owner && (
+              <div className="mt-6 flex justify-end">
+                <Button
+                  scheme="primary"
+                  onClick={() => {
+                    // TODO: 중계일정 관리 기능 구현
+                    alert("중계일정 관리 기능을 여기에 구현하세요!");
+                  }}
+                >
+                  중계 관리
+                </Button>
+              </div>
             )}
-          </ul>
+          </div>
         )}
       </div>
     </aside>

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailBroadcastTab.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailBroadcastTab.tsx
@@ -1,0 +1,57 @@
+import { FiTv } from "react-icons/fi";
+import Button from "../Common/Button";
+import type { RestaurantDetail } from "../../types/restaurant.types";
+
+export default function RestaurantDetailBroadcastTab({
+  detail,
+  onManage,
+}: {
+  detail: RestaurantDetail;
+  onManage?: () => void;
+}) {
+  return (
+    <div>
+      <ul className="flex flex-col gap-4">
+        {detail.broadcasts.length > 0 ? (
+          detail.broadcasts.map((b, idx) => (
+            <li
+              key={idx}
+              className="rounded-xl p-4 flex flex-col gap-1 border border-primary2"
+            >
+              <div className="flex items-center gap-2 mb-1">
+                <FiTv className="text-primary5" />
+                <span className="font-semibold">
+                  {b.league} {b.sport}
+                </span>
+                <span className="ml-auto text-xs text-gray-400">
+                  {b.match_date} {b.match_time}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 text-base font-bold text-gray-800">
+                {b.team_one}
+                <span className="mx-1 text-primary5">vs</span>
+                {b.team_two}
+                {b.etc && (
+                  <span className="ml-2 text-xs bg-primary3 text-primary5 rounded px-2 py-0.5">
+                    {b.etc}
+                  </span>
+                )}
+              </div>
+            </li>
+          ))
+        ) : (
+          <li className="py-6 text-gray-400 text-center">
+            예정된 중계가 없습니다.
+          </li>
+        )}
+      </ul>
+      {detail.is_owner && (
+        <div className="mt-6 flex justify-end">
+          <Button scheme="primary" onClick={onManage}>
+            중계 관리
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailHeader.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailHeader.tsx
@@ -1,0 +1,9 @@
+const RestaurantDetailHeader = () => (
+  <div className="h-12 flex items-center pl-6 border-b border-gray-100">
+    <span className="text-2xl font-bold tracking-tight text-primary5 font-pretendard">
+      Playce
+    </span>
+  </div>
+);
+
+export default RestaurantDetailHeader;

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailHomeTab.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailHomeTab.tsx
@@ -1,0 +1,38 @@
+import { FiMapPin, FiClock, FiPhone, FiFileText } from "react-icons/fi";
+import type { RestaurantDetail } from "../../types/restaurant.types";
+
+export default function RestaurantDetailHomeTab({
+  detail,
+}: {
+  detail: RestaurantDetail;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      {detail.is_owner && (
+        <div className="flex items-center gap-2 mb-2">
+          <span className="px-2 py-1 bg-primary3 text-primary5 rounded text-xs font-bold">
+            내 가게
+          </span>
+        </div>
+      )}
+      <h2 className="text-2xl font-bold mb-2">{detail.store_name}</h2>
+      <p className="mb-2 text-gray-700">{detail.description}</p>
+      <div className="flex items-center gap-2">
+        <FiMapPin className="text-xl" />
+        <span>{detail.address}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <FiClock className="text-xl" />
+        <span>{detail.opening_hours}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <FiPhone className="text-xl" />
+        <span>{detail.phone}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <FiFileText className="text-xl" />
+        <span>{detail.type}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailImageSection.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailImageSection.tsx
@@ -1,0 +1,55 @@
+import { FaStar } from "react-icons/fa";
+import { FiStar, FiX } from "react-icons/fi";
+import type { RestaurantDetail } from "../../types/restaurant.types";
+
+interface RestaurantDetailImageSectionProps {
+  detail: RestaurantDetail;
+  isFavorite: boolean;
+  onToggleFavorite: () => void;
+  onClose?: () => void;
+}
+
+const RestaurantDetailImageSection = ({
+  detail,
+  isFavorite,
+  onToggleFavorite,
+  onClose,
+}: RestaurantDetailImageSectionProps) => (
+  <div className="w-full h-56 bg-gradient-to-tr via-white to-orange-50 flex items-center justify-center relative">
+    {detail.img_urls?.[0] ? (
+      <img
+        src={detail.img_urls[0]}
+        alt={detail.store_name}
+        className="w-full h-full object-cover rounded-b-xl"
+      />
+    ) : (
+      <span className="text-gray-400">이미지 없음</span>
+    )}
+    {/* 저장/공유 버튼 */}
+    <div className="absolute left-6 top-6 flex gap-3 z-10">
+      <button
+        onClick={onToggleFavorite}
+        className="bg-white/90 rounded-full p-2 shadow hover:bg-orange-50 transition"
+        aria-label={isFavorite ? "즐겨찾기 해제" : "즐겨찾기 추가"}
+      >
+        {isFavorite ? (
+          <FaStar className="text-yellow-400 text-lg" />
+        ) : (
+          <FiStar className="text-primary5 text-lg" />
+        )}
+      </button>
+    </div>
+    {/* 닫기(X) 버튼 */}
+    {onClose && (
+      <button
+        onClick={onClose}
+        className="absolute top-6 right-6 bg-white/90 rounded-full p-2 shadow hover:bg-orange-50 transition z-20"
+        aria-label="상세보기 닫기"
+      >
+        <FiX className="text-primary5 text-lg" />
+      </button>
+    )}
+  </div>
+);
+
+export default RestaurantDetailImageSection;

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailMenuTab.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailMenuTab.tsx
@@ -1,0 +1,38 @@
+import { FaUtensils } from "react-icons/fa";
+import type { RestaurantDetail } from "../../types/restaurant.types";
+
+export default function RestaurantDetailMenuTab({
+  detail,
+}: {
+  detail: RestaurantDetail;
+}) {
+  let menus: string[] = [];
+  if (typeof detail.menus === "string") {
+    menus = detail.menus
+      .split(",")
+      .map((m) => m.trim())
+      .filter(Boolean);
+  } else if (Array.isArray(detail.menus)) {
+    menus = detail.menus;
+  }
+
+  return (
+    <ul className="grid grid-cols-1 gap-3">
+      {menus.length > 0 ? (
+        menus.map((menu, idx) => (
+          <li
+            key={idx}
+            className={`flex items-center gap-3 px-5 py-3 ${
+              idx !== menus.length - 1 ? "border-b border-gray-200" : ""
+            }`}
+          >
+            <FaUtensils className="text-primary1 text-lg" />
+            <span className="font-medium text-gray-700">{menu}</span>
+          </li>
+        ))
+      ) : (
+        <li className="py-3 text-gray-400 text-center">메뉴 정보 없음</li>
+      )}
+    </ul>
+  );
+}

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailPhotoTab.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailPhotoTab.tsx
@@ -1,22 +1,60 @@
+import { useState } from "react";
 import type { RestaurantDetail } from "../../types/restaurant.types";
+import { FiX } from "react-icons/fi";
 
-export default function RestaurantDetailPhotoTab({ detail }: { detail: RestaurantDetail }) {
+export default function RestaurantDetailPhotoTab({
+  detail,
+}: {
+  detail: RestaurantDetail;
+}) {
   const images = detail.img_urls || [];
+  const [modalImg, setModalImg] = useState<string | null>(null);
+
   if (images.length === 0) {
-    return <div className="text-gray-400 text-center py-12">등록된 사진이 없습니다.</div>;
+    return (
+      <div className="text-gray-400 text-center py-12">
+        등록된 사진이 없습니다.
+      </div>
+    );
   }
+
   return (
-    <div className="grid grid-cols-2 gap-3">
-      {images.map((url, idx) => (
-        <img
-          key={idx}
-          src={url}
-          alt={`${detail.store_name} 사진 ${idx + 1}`}
-          className="w-full h-40 object-cover rounded-lg shadow cursor-pointer transition-transform hover:scale-105"
-          loading="lazy"
-          // 클릭 시 확대/모달 등 추가 가능
-        />
-      ))}
+    <div>
+      <div className="grid grid-cols-2 gap-3">
+        {images.map((url, idx) => (
+          <img
+            key={idx}
+            src={url}
+            alt={`${detail.store_name} 사진 ${idx + 1}`}
+            className="w-full h-40 object-cover rounded-lg shadow cursor-pointer transition-transform hover:scale-105"
+            loading="lazy"
+            onClick={() => setModalImg(url)}
+          />
+        ))}
+      </div>
+      {modalImg && (
+        <div
+          className="fixed inset-0 z-[9999] bg-black/80 flex items-center justify-center"
+          onClick={() => setModalImg(null)}
+        >
+          <div className="relative">
+            <img
+              src={modalImg}
+              alt="전체보기"
+              className="max-w-[90vw] max-h-[90vh] object-contain select-none"
+              style={{ boxShadow: "none", border: "none", background: "none" }}
+              onClick={(e) => e.stopPropagation()}
+            />
+            <button
+              onClick={() => setModalImg(null)}
+              className="absolute top-6 right-6 bg-white/90 rounded-full p-2 shadow hover:bg-orange-50 transition z-20"
+              aria-label="닫기"
+            >
+              <FiX className="text-primary5 text-lg" />
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailPhotoTab.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailPhotoTab.tsx
@@ -1,0 +1,22 @@
+import type { RestaurantDetail } from "../../types/restaurant.types";
+
+export default function RestaurantDetailPhotoTab({ detail }: { detail: RestaurantDetail }) {
+  const images = detail.img_urls || [];
+  if (images.length === 0) {
+    return <div className="text-gray-400 text-center py-12">등록된 사진이 없습니다.</div>;
+  }
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {images.map((url, idx) => (
+        <img
+          key={idx}
+          src={url}
+          alt={`${detail.store_name} 사진 ${idx + 1}`}
+          className="w-full h-40 object-cover rounded-lg shadow cursor-pointer transition-transform hover:scale-105"
+          loading="lazy"
+          // 클릭 시 확대/모달 등 추가 가능
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailTabs.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailTabs.tsx
@@ -1,0 +1,40 @@
+// RestaurantDetailTabs.tsx
+import { FiTv, FiImage } from "react-icons/fi";
+import { FaUtensils } from "react-icons/fa";
+import Button from "../Common/Button";
+import classNames from "classnames";
+
+// 사진 탭 추가
+const TABS = ["홈", "메뉴", "사진", "중계"] as const;
+type Tab = (typeof TABS)[number];
+
+interface RestaurantDetailTabsProps {
+  currentTab: Tab;
+  setCurrentTab: (tab: Tab) => void;
+}
+
+const RestaurantDetailTabs = ({
+  currentTab,
+  setCurrentTab,
+}: RestaurantDetailTabsProps) => (
+  <div className="flex border-b border-gray-200 bg-white sticky top-0 z-10">
+    {TABS.map((tab) => (
+      <Button
+        key={tab}
+        scheme="tab"
+        className={classNames(
+          "flex-1 py-3 flex items-center justify-center gap-1 transition-all",
+          currentTab === tab && "text-primary5 border-primary5 bg-white"
+        )}
+        onClick={() => setCurrentTab(tab)}
+      >
+        {tab === "메뉴" && <FaUtensils className="text-base" />}
+        {tab === "사진" && <FiImage className="text-base" />}
+        {tab === "중계" && <FiTv className="text-base" />}
+        {tab}
+      </Button>
+    ))}
+  </div>
+);
+
+export default RestaurantDetailTabs;

--- a/frontend/src/components/Search/SearchResultList.tsx
+++ b/frontend/src/components/Search/SearchResultList.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import SearchResultItem from "./SearchResultItem";
 import { useSearchStore } from "../../stores/searchStore";
 import { sortSearchResults } from "../../utils/sortUtils";
+import RestaurantDetailComponent from "../RestaurantDetail/RestaurantDetail";
 
 const SearchResultList = () => {
   const isSearching = useSearchStore((state) => state.isSearching);
@@ -8,6 +10,9 @@ const SearchResultList = () => {
   const results = useSearchStore((state) => state.results);
   const sort = useSearchStore((state) => state.sort);
   const setSort = useSearchStore((state) => state.setSort);
+
+  // 상세보기용 state 추가
+  const [selectedStoreId, setSelectedStoreId] = useState<number | null>(null);
 
   const sortedResults = sortSearchResults(results, sort);
 
@@ -68,10 +73,24 @@ const SearchResultList = () => {
               imgUrl: item.img_url || "/noimg.png",
             };
 
-            return <SearchResultItem key={item.id} data={displayItem} />;
+            return (
+              <SearchResultItem
+                key={item.id}
+                data={displayItem}
+                onClick={() => setSelectedStoreId(item.id)}
+              />
+            );
           })
         )}
       </div>
+
+      {/* 상세보기 모달/사이드바 */}
+      {selectedStoreId !== null && (
+        <RestaurantDetailComponent
+          storeId={selectedStoreId}
+          onClose={() => setSelectedStoreId(null)}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/types/restaurant.types.ts
+++ b/frontend/src/types/restaurant.types.ts
@@ -30,7 +30,7 @@ export interface RestaurantDetail {
   img_urls: string[];
   description: string;
   broadcasts: Broadcast[];
-  // is_owner?: boolean;   // 필요하면 추가
+  is_owner?: boolean;
 }
 
 export interface MyStore {


### PR DESCRIPTION
## 📎 관련 이슈
#89

## 📌 PR 설명
- 가게 상세보기 상태관리 리팩토링 ( store_id 만 props로 내려줘도 기능 가능)
- 상세보기 이미지/탭/홈/메뉴/중계 등 세부 컴포넌트 분리
- 사진탭 추가 및 전체보기(모달) 기능 구현
- 상세보기 내 "내 가게" 뱃지, 중계 일정 관리 버튼 등 UI 추가
- 통합 검색 결과 -> 가게 상세보기 API 연결
- is_owner에 따른상세 보기에서  중계 일정 관리 추가

## ✅ 작업 내용
- [x] 기능 구현
- [x] UI 수정
- [ ] 버그 수정


## 🧪 테스트 방법 (선택)
어떻게 테스트했는지, 테스트할 방법이 있다면 적어주세요.

## 💬 기타

![스크린샷 2025-07-08 123946](https://github.com/user-attachments/assets/b406c6d7-4096-4f2c-9d19-8e8f7e5ddbaa)

![스크린샷 2025-07-08 123935](https://github.com/user-attachments/assets/5f8b88a7-46cc-43b1-b1fa-dbc2ef4f9bb1)


![image](https://github.com/user-attachments/assets/b917d9d3-b2fe-40c6-88cc-25c3edd5b32d)

![image](https://github.com/user-attachments/assets/f4cd3b2b-b655-4251-93d0-b7bbb2214fa0)



