### PR TITLE
Fix: 종목 변경 시 기존 선택된 리그 초기화되는 문제 수정 (#63)

### DIFF
--- a/frontend/src/stores/sportStore.ts
+++ b/frontend/src/stores/sportStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type {SelectedSports} from "../types/staticdata";
+import type { SelectedSports } from "../types/staticdata";
 
 interface SportState {
   sport: string;
@@ -14,7 +14,8 @@ export const useSportStore = create<SportState>((set, get) => ({
   sport: "",
   selectedLeagues: [],
 
-  setSport: (sport) => set({ sport, selectedLeagues: [] }),
+  setSport: (sport) =>
+    set((prev) => ({ sport, selectedLeagues: prev.selectedLeagues })),
 
   setSelectedLeagues: (leagues) => set({ selectedLeagues: leagues }),
 


### PR DESCRIPTION
## 📎 관련 이슈
`#63` 


## 📌 PR 설명
기존 경기 검색에서 종목 변경 시 선택된 토글이 초기화되는 문제를 해결

## ✅ 작업 내용
- [ ] 기능 구현
- [ ] UI 수정
- [x] 버그 수정


## 🧪 테스트 방법 (선택)
어떻게 테스트했는지, 테스트할 방법이 있다면 적어주세요.


## 💬 기타
추가로 공유할 내용이나 주의 사항
