### PR TITLE
Fe/#56/style edit

### DIFF
--- a/frontend/src/components/FavoriteSidebar/FavoriteSidebar.tsx
+++ b/frontend/src/components/FavoriteSidebar/FavoriteSidebar.tsx
@@ -25,7 +25,7 @@ export default function FavoriteSidebar() {
   };
 
   return (
-    <section className="w-full bg-white px-2 pt-6 pb-5 rounded-2xl border border-gray-100">
+    <section className="w-full bg-white px-1.5 pt-6 pb-2 rounded-2xl border border-gray-100">
       <button
         className="flex items-center w-full h-8 border-b border-gray-100 bg-white group px-3 pb-3"
         onClick={() => setExpanded((prev) => !prev)}

--- a/frontend/src/components/FavoriteSidebar/FavoriteSidebar.tsx
+++ b/frontend/src/components/FavoriteSidebar/FavoriteSidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { FiStar } from "react-icons/fi";
+import { FaStar } from "react-icons/fa"; // 가득 찬 노란 별 아이콘 import
 import useFavoriteStore from "../../stores/favoriteStore";
 import useAuthStore from "../../stores/authStore";
 import RestaurantCardList from "../RestaurantCardList/RestaurantCardList";
@@ -31,7 +31,8 @@ export default function FavoriteSidebar() {
         onClick={() => setExpanded((prev) => !prev)}
         aria-label="즐겨찾기 펼치기"
       >
-        <FiStar className="text-primary1 text-xl mr-2" />
+        {/* 노란색 가득 찬 별 아이콘 */}
+        <FaStar className="text-yellow-400 text-xl mr-2" />
         <span className="text-lg font-bold flex-1 text-left">즐겨찾기</span>
         <span className="text-xs text-gray-400 mr-2">
           {expanded ? "접기" : "더보기"}

--- a/frontend/src/components/FavoriteSidebar/FavoriteSidebar.tsx
+++ b/frontend/src/components/FavoriteSidebar/FavoriteSidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { FaStar } from "react-icons/fa"; // 가득 찬 노란 별 아이콘 import
+import { FaStar } from "react-icons/fa";
 import useFavoriteStore from "../../stores/favoriteStore";
 import useAuthStore from "../../stores/authStore";
 import RestaurantCardList from "../RestaurantCardList/RestaurantCardList";
@@ -25,13 +25,12 @@ export default function FavoriteSidebar() {
   };
 
   return (
-    <section className="w-full bg-white mt-6">
+    <section className="w-full bg-white px-2 pt-6 pb-5 rounded-2xl border border-gray-100">
       <button
         className="flex items-center w-full h-8 border-b border-gray-100 bg-white group px-3 pb-3"
         onClick={() => setExpanded((prev) => !prev)}
         aria-label="즐겨찾기 펼치기"
       >
-        {/* 노란색 가득 찬 별 아이콘 */}
         <FaStar className="text-yellow-400 text-xl mr-2" />
         <span className="text-lg font-bold flex-1 text-left">즐겨찾기</span>
         <span className="text-xs text-gray-400 mr-2">

--- a/frontend/src/components/Map/SpotRefreshButton.tsx
+++ b/frontend/src/components/Map/SpotRefreshButton.tsx
@@ -10,8 +10,12 @@ const SpotRefreshButton = () => {
     <Button
       icon={<IoReloadOutline />}
       size="medium"
-      scheme="secondary"
-      className="absolute top-[80px] left-1/2 -translate-x-1/2 z-10 rounded-lg"
+      className={`
+    absolute top-[80px] left-1/2 -translate-x-1/2 z-10 rounded-lg
+    bg-primary5 border border-primary5 text-white
+    hover:bg-white hover:text-primary5 hover:border-primary5
+    transition-colors
+  `}
       onClick={async () => {
         const res = await searchNearby({
           lat: position.lat,

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailBroadcastTab.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailBroadcastTab.tsx
@@ -10,6 +10,12 @@ function getKoreanDateString(dateStr: string): string {
   return `${date.getMonth() + 1}월 ${date.getDate()}일`;
 }
 
+// 시간에서 초 제거 ("HH:mm:ss" -> "HH:mm")
+function formatTime(timeStr: string | undefined | null): string {
+  if (!timeStr) return "";
+  return timeStr.split(":").slice(0, 2).join(":");
+}
+
 // 날짜별 그룹핑
 function groupByDate(broadcasts: Broadcast[]): Record<string, Broadcast[]> {
   return broadcasts.reduce((acc, b) => {
@@ -92,7 +98,7 @@ export default function RestaurantDetailBroadcastTab({
                       {b.sport}
                     </span>
                     <span className="ml-auto text-xs text-gray-400">
-                      {b.match_time}
+                      {formatTime(b.match_time)}
                     </span>
                   </div>
                   <div className="flex items-center gap-2 text-base font-bold text-gray-800">
@@ -164,7 +170,7 @@ export default function RestaurantDetailBroadcastTab({
                           {b.sport}
                         </span>
                         <span className="ml-auto text-xs text-gray-400">
-                          {b.match_time}
+                          {formatTime(b.match_time)}
                         </span>
                       </div>
                       <div className="flex items-center gap-2 text-base font-bold text-gray-500">

--- a/frontend/src/components/TodayBroadcasts/TodayBroadCasts.tsx
+++ b/frontend/src/components/TodayBroadcasts/TodayBroadCasts.tsx
@@ -50,84 +50,93 @@ export default function TodayBroadcastSidebar() {
       <div className="text-sm text-gray-500 mb-4 font-medium tracking-tight">
         지도에서 탐색한 가게의 중계일정만 보여드려요
       </div>
-      {/* 종목 탭 */}
-      <nav className="flex gap-2 mb-4 border-b border-gray-100 pb-1">
-        {SPORTS.length === 0 ? (
-          <span className="text-gray-400 text-sm">중계 종목 없음</span>
-        ) : (
-          SPORTS.map((sport) => (
-            <button
-              key={sport}
-              onClick={() => setSelectedSport(sport)}
-              className={`px-3 pb-1 text-sm font-semibold rounded-t-lg border-b-2 ${
-                selectedSport === sport
-                  ? "border-primary5 text-primary5 bg-primary4"
-                  : "border-transparent text-gray-400 hover:text-primary5 hover:bg-primary4/50"
-              } transition-colors`}
-              style={{ background: "none" }}
-            >
-              {sport}
-            </button>
-          ))
-        )}
-      </nav>
-      {/* 카드형 경기 리스트 */}
-      <ul>
-        {filtered.length === 0 ? (
-          <li className="text-gray-400 py-8 text-center text-base">
-            오늘 중계되는 경기가 없습니다.
-          </li>
-        ) : (
-          filtered.map((game, idx) => (
-            <li
-              key={idx}
-              className="bg-white rounded-xl border border-gray-200 px-4 py-3 mb-3 flex items-center gap-4 cursor-pointer hover:bg-primary4 transition-colors"
-              onClick={() => setSelectedStoreId(game.store_id)}
-            >
-              {/* 대표 이미지(없으면 아이콘) */}
-              {game.main_img ? (
-                <img
-                  src={game.main_img}
-                  alt={game.store_name}
-                  className="w-12 h-12 rounded-lg object-cover bg-gray-100 flex-shrink-0"
-                />
-              ) : (
-                <div className="w-12 h-12 rounded-lg bg-gray-100 flex items-center justify-center text-gray-300 text-2xl">
-                  <FiImage />
-                </div>
-              )}
-              {/* 경기 정보 */}
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 mb-0.5">
-                  <span className="font-bold text-primary5 truncate">
-                    {game.store_name}
-                  </span>
-                  <span className="text-xs bg-primary4 text-primary5 rounded px-2 py-0.5 ml-2">
-                    {game.league}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="font-semibold text-gray-800">
-                    {game.team_one}
-                  </span>
-                  <span className="mx-1 text-xs text-gray-400">vs</span>
-                  <span className="font-semibold text-gray-800">
-                    {game.team_two}
-                  </span>
-                  <span className="ml-auto text-xs text-gray-500">
-                    {game.match_time}
-                  </span>
-                </div>
-                {game.etc && (
-                  <div className="mt-1 text-xs text-primary5">{game.etc}</div>
-                )}
-              </div>
-            </li>
-          ))
-        )}
-      </ul>
-      {/* 하단 여백 추가 */}
-      <div className="h-8" />
+
+      {/* 오늘 중계되는 경기가 없으면 종목탭 없이 안내문구만 노출 */}
+      {todayBroadcasts.length === 0 ? (
+        <div className="text-gray-400 py-8 text-center text-base">
+          오늘 중계되는 경기가 없습니다.
+        </div>
+      ) : (
+        <>
+          {/* 종목 탭 */}
+          <nav className="flex gap-2 mb-4 border-b border-gray-100 pb-1">
+            {SPORTS.map((sport) => (
+              <button
+                key={sport}
+                onClick={() => setSelectedSport(sport)}
+                className={`px-3 pb-1 text-sm font-semibold rounded-t-lg border-b-2 ${
+                  selectedSport === sport
+                    ? "border-primary5 text-primary5 bg-primary4"
+                    : "border-transparent text-gray-400 hover:text-primary5 hover:bg-primary4/50"
+                } transition-colors`}
+                style={{ background: "none" }}
+              >
+                {sport}
+              </button>
+            ))}
+          </nav>
+          {/* 카드형 경기 리스트 */}
+          <ul>
+            {filtered.length === 0 ? (
+              <li className="text-gray-400 py-8 text-center text-base">
+                오늘 중계되는 경기가 없습니다.
+              </li>
+            ) : (
+              filtered.map((game, idx) => (
+                <li
+                  key={idx}
+                  className="bg-white rounded-xl border border-gray-200 px-4 py-3 mb-3 flex items-center gap-4 cursor-pointer hover:bg-primary4 transition-colors"
+                  onClick={() => setSelectedStoreId(game.store_id)}
+                >
+                  {/* 대표 이미지(없으면 아이콘) */}
+                  {game.main_img ? (
+                    <img
+                      src={game.main_img}
+                      alt={game.store_name}
+                      className="w-12 h-12 rounded-lg object-cover bg-gray-100 flex-shrink-0"
+                    />
+                  ) : (
+                    <div className="w-12 h-12 rounded-lg bg-gray-100 flex items-center justify-center text-gray-300 text-2xl">
+                      <FiImage />
+                    </div>
+                  )}
+                  {/* 경기 정보 */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-0.5">
+                      <span className="font-bold text-primary5 truncate">
+                        {game.store_name}
+                      </span>
+                      <span className="text-xs bg-primary4 text-primary5 rounded px-2 py-0.5 ml-2">
+                        {game.league}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold text-gray-800">
+                        {game.team_one}
+                      </span>
+                      <span className="mx-1 text-xs text-gray-400">vs</span>
+                      <span className="font-semibold text-gray-800">
+                        {game.team_two}
+                      </span>
+                      <span className="ml-auto text-xs text-gray-500">
+                        {game.match_time}
+                      </span>
+                    </div>
+                    {game.etc && (
+                      <div className="mt-1 text-xs text-primary5">
+                        {game.etc}
+                      </div>
+                    )}
+                  </div>
+                </li>
+              ))
+            )}
+          </ul>
+          {/* 하단 여백 추가 */}
+          <div className="h-8" />
+        </>
+      )}
+
       {/* 상세보기 모달/사이드바 */}
       {selectedStoreId && (
         <RestaurantDetailComponent

--- a/frontend/src/components/TodayBroadcasts/TodayBroadCasts.tsx
+++ b/frontend/src/components/TodayBroadcasts/TodayBroadCasts.tsx
@@ -4,6 +4,12 @@ import useMapStore from "../../stores/mapStore";
 import RestaurantDetailComponent from "../RestaurantDetail/RestaurantDetail";
 import type { Broadcast } from "../../types/restaurant.types";
 
+// 시간 포맷팅 함수 추가
+function formatTime(timeStr: string | undefined | null): string {
+  if (!timeStr) return "";
+  return timeStr.split(":").slice(0, 2).join(":");
+}
+
 export default function TodayBroadcastSidebar() {
   const restaurants = useMapStore((state) => state.restaurants);
   const [selectedSport, setSelectedSport] = useState<string>("축구");
@@ -119,7 +125,7 @@ export default function TodayBroadcastSidebar() {
                         {game.team_two}
                       </span>
                       <span className="ml-auto text-xs text-gray-500">
-                        {game.match_time}
+                        {formatTime(game.match_time)}
                       </span>
                     </div>
                     {game.etc && (

--- a/frontend/src/components/TodayBroadcasts/TodayBroadCasts.tsx
+++ b/frontend/src/components/TodayBroadcasts/TodayBroadCasts.tsx
@@ -47,7 +47,7 @@ export default function TodayBroadcastSidebar() {
   const filtered = todayBroadcasts.filter((b) => b.sport === selectedSport);
 
   return (
-    <section className="w-full bg-white px-5 pt-6 pb-10 rounded-2xl border border-gray-100">
+    <section className="w-full bg-white px-5 pt-1 pb-10 rounded-2xl border border-gray-100">
       {/* 헤더 */}
       <div className="flex items-center gap-2 mb-1">
         <FiTv className="text-primary1 text-xl" />


### PR DESCRIPTION
## 📎 관련 이슈
#56 


## 📌 PR 설명
- 사이드바 즐겨찾기 아이콘 변경
- 사이드바에서 즐겨찾기, 오늘의 중계일정 패딩 재조정
- 오늘의 중계 일정 결과 없을때 종목 탭 표현 삭제
- 오늘의 중계 & 상세보기 중계 탭 시간 표현 변경 (초단위 삭제)
- 이위치에서 재탐색 색상 변경 (기존 색상, 호버 상태 색상 반대로)

## ✅ 작업 내용
- [ ] 기능 구현
- [x] UI 수정
- [ ] 버그 수정


## 🧪 테스트 방법 (선택)
어떻게 테스트했는지, 테스트할 방법이 있다면 적어주세요.


## 💬 기타
추가로 공유할 내용이나 주의 사항
