### PR TITLE
Fe/#110/broadcast refactor

### DIFF
--- a/frontend/src/components/Mypage/MypageModal.tsx
+++ b/frontend/src/components/Mypage/MypageModal.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import ModalBase from "../Common/ModalBase";
 import Sidebar from "../Mypage/Sidebar";
 import FavoriteList from "./FavoriteList";
@@ -8,14 +7,12 @@ import useMypageStore from "../../stores/mypageStore";
 import { useUserInfo } from "../../hooks/useUser";
 import { FiPlus } from "react-icons/fi";
 
-type TabType = "favorite" | "profile" | "restaurant";
-
 export interface MypageProps {
   onClose: () => void;
 }
 
 const MypageModal = ({ onClose }: MypageProps) => {
-  const [selectedTab, setSelectedTab] = useState<TabType>("favorite");
+  const { selectedTab, setSelectedTab } = useMypageStore();
   const { restaurantSubpage, setRestaurantSubpage } = useMypageStore();
 
   const handleClose = () => {

--- a/frontend/src/components/Mypage/RestaurantManage/Broadcasts/BroadcastActionButtons.tsx
+++ b/frontend/src/components/Mypage/RestaurantManage/Broadcasts/BroadcastActionButtons.tsx
@@ -1,4 +1,5 @@
-import { FaEdit, FaRegTrashAlt } from "react-icons/fa";
+import { FiEdit2, FiTrash2 } from "react-icons/fi";
+import Button from "../../../Common/Button";
 
 interface BroadcastActionButtonsProps {
   onEdit: () => void;
@@ -10,13 +11,20 @@ const BroadcastActionButtons = ({
   onDelete,
 }: BroadcastActionButtonsProps) => {
   return (
-    <>
-      <FaEdit className="cursor-pointer" onClick={onEdit} />
-      <FaRegTrashAlt
-        className="cursor-pointer text-red-500"
-        onClick={onDelete}
+    <div className="flex items-center gap-3 mr-3">
+      <Button
+        onClick={onEdit}
+        scheme="storeCircle"
+        icon={<FiEdit2 className="text-blue-500 text-xl" />}
+        hoverColor="blue-50"
       />
-    </>
+      <Button
+        onClick={onDelete}
+        scheme="storeCircle"
+        icon={<FiTrash2 className="text-red-500 text-xl" />}
+        hoverColor="red-50"
+      />
+    </div>
   );
 };
 

--- a/frontend/src/components/Mypage/RestaurantManage/Broadcasts/BroadcastView.tsx
+++ b/frontend/src/components/Mypage/RestaurantManage/Broadcasts/BroadcastView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from "react-icons/md";
-import { FaBars, FaPlus, FaRegCalendarAlt } from "react-icons/fa";
+import { FaBars, FaRegCalendarAlt } from "react-icons/fa";
 
 import TabList from "./TabLists";
 import Calendar from "./Calendar";
@@ -12,6 +12,7 @@ import useBroadcastFormStore from "../../../../stores/broadcastFormStore";
 import { getBroadcast } from "../../../../api/broadcast.api";
 import getDaysInMonth from "../../../../utils/getDaysInMonth";
 import useMypageStore from "../../../../stores/mypageStore";
+import FloatingRegisterButton from "./FloatingRegisterButton";
 
 const BroadcastView = () => {
   const { yearNum, monthNum } = dateInfo;
@@ -33,7 +34,7 @@ const BroadcastView = () => {
     setBroadcastLists,
   } = useBroadcastStore();
 
-  const { setEditingId, resetForm } = useBroadcastFormStore();
+  const { editingId } = useBroadcastFormStore();
 
   const isInTwoMonths = (year: number, month: number) => {
     const target = new Date(year, month - 1);
@@ -81,7 +82,7 @@ const BroadcastView = () => {
     );
   }
 
-  if (formMode === "edit") {
+  if (formMode === "edit" && editingId) {
     return (
       <BroadcastEdit
         onClose={() => {
@@ -92,18 +93,23 @@ const BroadcastView = () => {
     );
   }
 
+  const today = new Date();
+  const todayYear = today.getFullYear();
+  const todayMonth = today.getMonth() + 1;
+  const todayDate = today.getDate();
+
   return (
-    <div className="flex flex-col pl-2">
-      <div className="flex text-[28px] items-center justify-between mb-5 gap-3">
+    <div className="flex flex-col pl-2 relative h-full">
+      <div className="flex text-[28px] items-center justify-between mb-3 gap-3">
         <button
-          className="text-[25px]"
+          className="text-[16px] px-2 py-1 rounded bg-primary1 text-mainText hover:bg-primary5 hover:text-white transition"
           onClick={() => {
-            resetForm();
-            setEditingId(null);
-            setRestaurantSubpage("broadcast-register");
+            setYear(todayYear);
+            setMonth(todayMonth);
+            setDate(todayDate);
           }}
         >
-          <FaPlus />
+          오늘
         </button>
 
         <div className="flex items-center gap-3">
@@ -144,15 +150,22 @@ const BroadcastView = () => {
         </button>
       </div>
 
-      {viewOption === "tab" ? (
-        <TabList
-          onEditClick={() => {
-            setFormMode("edit");
-          }}
+      <div className="relative h-full w-full">
+        <div className="min-h-[400px]">
+          {viewOption === "calendar" ? (
+            <Calendar />
+          ) : (
+            <TabList />
+          )}
+        </div>
+
+        <FloatingRegisterButton
+          className={`absolute bottom-[-2px] right-[29px] translate-x-[22px] ${
+            viewOption === "tab" ? "translate-y-[7px]" : ""
+          }`}
+          onClick={() => setRestaurantSubpage("broadcast-register")}
         />
-      ) : (
-        <Calendar />
-      )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/Mypage/RestaurantManage/Broadcasts/Calendar.tsx
+++ b/frontend/src/components/Mypage/RestaurantManage/Broadcasts/Calendar.tsx
@@ -3,7 +3,8 @@ import { getDayIdx } from "../../../../utils/getDay";
 import getDaysInMonth from "../../../../utils/getDaysInMonth";
 
 const Calendar = () => {
-  const { year, month, broadcastLists } = useBroadcastStore();
+  const { year, month, setDate, setViewOption, broadcastLists } =
+    useBroadcastStore();
   const daysInMonth = getDaysInMonth(year, month);
   const firstDayOfWeek = getDayIdx(year, month, 1); // 시작 요일
   const weeks: (number | null)[][] = [];
@@ -27,6 +28,11 @@ const Calendar = () => {
 
   const weekdayLabels = ["일", "월", "화", "수", "목", "금", "토"];
 
+  const today = new Date();
+  const todayYear = today.getFullYear();
+  const todayMonth = today.getMonth() + 1;
+  const todayDate = today.getDate();
+
   const broadcastCountMap = broadcastLists.reduce((acc, item) => {
     const date = new Date(item.match_date);
     const y = date.getFullYear();
@@ -39,50 +45,66 @@ const Calendar = () => {
   }, {} as Record<string, number>);
 
   return (
-    <div className="border-[2px]">
-      <div className="grid grid-cols-7 font-semibold">
-        {weekdayLabels.map((day) => (
-          <div
-            className="flex justify-center items-center py-2 px-4 border-[1px] border-b-[2px]"
-            key={day}
-          >
-            {day}
-          </div>
-        ))}
-      </div>
-
-      <div className="grid grid-cols-7 ">
-        {weeks.flat().map((day, idx) => {
-          const key = day ? `${year}-${month}-${day}` : null;
-
-          return (
+    <div className="min-h-[415px]">
+      <div className="border-[2px]">
+        <div className="grid grid-cols-7 font-semibold">
+          {weekdayLabels.map((day) => (
             <div
-              className={`flex justify-center items-center border-[1px] ${
-                day ? "hover:bg-lightgray hover:cursor-pointer" : ""
-              }`}
-              key={idx}
+              className="flex justify-center items-center py-2 px-4 border-[1px] border-b-[2px]"
+              key={day}
             >
-              {day ? (
-                <div className="flex flex-col w-full px-3 py-2 gap-1">
-                  <div className="flex justify-center font-semibold">
-                    <span>{day}</span>
-                  </div>
-                  <div>
-                    {key && broadcastCountMap[key] ? (
-                      <span className="border-l-[3px] border-primary5 pl-1">
-                        {broadcastCountMap[key]}개
-                      </span>
-                    ) : (
-                      <span>&nbsp;</span>
-                    )}
-                  </div>
-                </div>
-              ) : (
-                ""
-              )}
+              {day}
             </div>
-          );
-        })}
+          ))}
+        </div>
+
+        <div className="grid grid-cols-7">
+          {weeks.flat().map((day, idx) => {
+            const key = day ? `${year}-${month}-${day}` : null;
+            const isToday =
+              year === todayYear && month === todayMonth && day === todayDate;
+
+            return (
+              <div
+                className={`flex justify-center items-center border-[1px] ${
+                  day ? "hover:bg-lightgray hover:cursor-pointer" : ""
+                }`}
+                key={idx}
+              >
+                {day ? (
+                  <div
+                    className="flex flex-col w-full px-3 py-2 gap-1"
+                    onClick={() => {
+                      setDate(day);
+                      setViewOption("tab");
+                    }}
+                  >
+                    <div className="flex justify-center font-semibold">
+                      {isToday ? (
+                        <div className="w-6 h-6 flex items-center justify-center rounded-full bg-primary5 text-white">
+                          <span>{day}</span>
+                        </div>
+                      ) : (
+                        <span>{day}</span>
+                      )}
+                    </div>
+                    <div>
+                      {key && broadcastCountMap[key] ? (
+                        <span className="border-l-[3px] border-primary5 pl-1">
+                          {broadcastCountMap[key]}개
+                        </span>
+                      ) : (
+                        <span>&nbsp;</span>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  ""
+                )}
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/Mypage/RestaurantManage/Broadcasts/FloatingRegisterButton.tsx
+++ b/frontend/src/components/Mypage/RestaurantManage/Broadcasts/FloatingRegisterButton.tsx
@@ -1,0 +1,22 @@
+import { FiPlus } from "react-icons/fi";
+
+interface FloatingRegisterButtonProps {
+  onClick: () => void;
+  className?: string;
+}
+
+const FloatingRegisterButton = ({
+  onClick,
+  className = "",
+}: FloatingRegisterButtonProps) => {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-12 h-12 rounded-full bg-primary5 text-white shadow-lg flex items-center justify-center hover:bg-primary4 transition-all ${className}`}
+    >
+      <FiPlus />
+    </button>
+  );
+};
+
+export default FloatingRegisterButton;

--- a/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
@@ -110,6 +110,7 @@ export default function RestaurantDetailComponent({
         {currentTab === "중계" && (
           <RestaurantDetailBroadcastTab
             detail={detail}
+            storeId={storeId}
             onManage={() => alert("중계일정 관리 기능을 여기에 구현하세요!")}
           />
         )}

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailBroadcastTab.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailBroadcastTab.tsx
@@ -3,6 +3,8 @@ import { FiTv, FiChevronDown, FiChevronUp } from "react-icons/fi";
 import Button from "../Common/Button";
 import type { RestaurantDetail, Broadcast } from "../../types/restaurant.types";
 import EmptyMessage from "./EmptyMessage";
+import useBroadcastStore from "../../stores/broadcastStore";
+import useMypageStore from "../../stores/mypageStore";
 
 // 날짜를 "7월 9일" 형식으로 변환
 function getKoreanDateString(dateStr: string): string {
@@ -31,10 +33,12 @@ function compareDate(a: string, b: string): number {
 
 interface RestaurantDetailBroadcastTabProps {
   detail: RestaurantDetail;
+  storeId: number;
 }
 
 export default function RestaurantDetailBroadcastTab({
   detail,
+  storeId,
 }: RestaurantDetailBroadcastTabProps) {
   const [showPast, setShowPast] = useState<boolean>(false);
   const today: string = new Date().toISOString().slice(0, 10);
@@ -62,6 +66,10 @@ export default function RestaurantDetailBroadcastTab({
   const sortedPastDates: string[] = Object.keys(groupedPast).sort((a, b) =>
     compareDate(b, a)
   );
+
+  const { setStore } = useBroadcastStore();
+  const { setRestaurantSubpage, setSelectedTab, setIsMypageOpen } =
+    useMypageStore();
 
   return (
     <div>
@@ -102,9 +110,15 @@ export default function RestaurantDetailBroadcastTab({
                     </span>
                   </div>
                   <div className="flex items-center gap-2 text-base font-bold text-gray-800">
-                    {b.team_one}
-                    <span className="mx-1 text-primary5">vs</span>
-                    {b.team_two}
+                    {b.team_one && b.team_two ? (
+                      <>
+                        <span>{b.team_one}</span>
+                        <span className="mx-1 text-primary5">vs</span>
+                        <span>{b.team_two}</span>
+                      </>
+                    ) : (
+                      <></>
+                    )}
                     {b.etc && (
                       <span className="ml-2 text-xs bg-primary3 text-primary5 rounded px-2 py-0.5">
                         {b.etc}
@@ -174,9 +188,15 @@ export default function RestaurantDetailBroadcastTab({
                         </span>
                       </div>
                       <div className="flex items-center gap-2 text-base font-bold text-gray-500">
-                        {b.team_one}
-                        <span className="mx-1 text-gray-400">vs</span>
-                        {b.team_two}
+                        {b.team_one && b.team_two ? (
+                          <>
+                            <span>{b.team_one}</span>
+                            <span className="mx-1 text-primary5">vs</span>
+                            <span>{b.team_two}</span>
+                          </>
+                        ) : (
+                          <></>
+                        )}
                         {b.etc && (
                           <span className="ml-2 text-xs bg-gray-100 text-gray-400 rounded px-2 py-0.5">
                             {b.etc}
@@ -192,10 +212,19 @@ export default function RestaurantDetailBroadcastTab({
         )}
       </div>
 
-      {/* 중계 관리 버튼 (하단에만 표시) */}
       {detail.is_owner && (
         <div className="mt-10 flex justify-end">
-          <Button scheme="primary">중계 관리</Button>
+          <Button
+            scheme="primary"
+            onClick={() => {
+              setSelectedTab("restaurant");
+              setStore(detail.store_name, storeId);
+              setRestaurantSubpage("schedule-view-broadcasts");
+              setIsMypageOpen(true);
+            }}
+          >
+            중계 관리
+          </Button>
         </div>
       )}
     </div>

--- a/frontend/src/components/Select/LeagueSelect.tsx
+++ b/frontend/src/components/Select/LeagueSelect.tsx
@@ -13,7 +13,9 @@ const LeagueSelect = ({
 }: LeagueSelectProps) => {
   return (
     <div>
-      <label className="mb-2 block text-mainText">리그</label>
+      <label className="mb-2 block font-semibold text-mainText">
+        리그 <span className="text-red-500">*</span>
+      </label>
       <select
         value={value}
         onChange={(e) => {

--- a/frontend/src/components/Select/SportSelect.tsx
+++ b/frontend/src/components/Select/SportSelect.tsx
@@ -7,7 +7,9 @@ interface SportSelectProps {
 const SportSelect = ({ value, options, onChange }: SportSelectProps) => {
   return (
     <div>
-      <label className="mb-2 block text-mainText">종목</label>
+      <label className="mb-2 block font-semibold text-mainText">
+        종목 <span className="text-red-500">*</span>
+      </label>
       <select
         value={value}
         onChange={(e) => {
@@ -18,7 +20,9 @@ const SportSelect = ({ value, options, onChange }: SportSelectProps) => {
         }}
         className="w-full p-2 border rounded-md hover:border-primary5 focus:border-primary5 focus:ring-1 focus:ring-primary1 focus:outline-none"
       >
-        <option value="" className="text-mainText">종목 선택</option>
+        <option value="" className="text-mainText">
+          종목 선택
+        </option>
         {options.map((s) => (
           <option key={s.id} value={s.id}>
             {s.name}

--- a/frontend/src/components/TodayBroadcasts/TodayBroadCasts.tsx
+++ b/frontend/src/components/TodayBroadcasts/TodayBroadCasts.tsx
@@ -117,13 +117,19 @@ export default function TodayBroadcastSidebar() {
                       </span>
                     </div>
                     <div className="flex items-center gap-2">
-                      <span className="font-semibold text-gray-800">
-                        {game.team_one}
-                      </span>
-                      <span className="mx-1 text-xs text-gray-400">vs</span>
-                      <span className="font-semibold text-gray-800">
-                        {game.team_two}
-                      </span>
+                      {game.team_one && game.team_two ? (
+                        <>
+                          <span className="font-semibold text-gray-800">
+                            {game.team_one}
+                          </span>
+                          <span className="mx-1 text-xs text-gray-400">vs</span>
+                          <span className="font-semibold text-gray-800">
+                            {game.team_two}
+                          </span>
+                        </>
+                      ) : (
+                        <></>
+                      )}
                       <span className="ml-auto text-xs text-gray-500">
                         {formatTime(game.match_time)}
                       </span>

--- a/frontend/src/stores/mypageStore.ts
+++ b/frontend/src/stores/mypageStore.ts
@@ -1,12 +1,16 @@
 import { create } from "zustand";
 import type { ExtendedSubpage } from "../types/restaurant-manage.types";
 
+type TabType = "favorite" | "profile" | "restaurant";
+
 interface MypageState {
   isMypageOpen: boolean;
+  selectedTab: TabType;
   restaurantSubpage: ExtendedSubpage;
   restaurantEditId: number | null;
   restaurantEditName: string | null;
   setIsMypageOpen: (mypage: boolean) => void;
+  setSelectedTab: (tab: TabType) => void;
   setRestaurantSubpage: (subpage: ExtendedSubpage) => void;
   setRestaurantEditId: (restaurant: number) => void;
   setRestaurantEditName: (restaurant: string) => void;
@@ -14,11 +18,15 @@ interface MypageState {
 
 const useMypageStore = create<MypageState>((set) => ({
   isMypageOpen: false,
+  selectedTab: "favorite",
   restaurantSubpage: "restaurant-home",
   restaurantEditId: null,
   restaurantEditName: null,
   setIsMypageOpen: (mypage) => {
     set({ isMypageOpen: mypage });
+  },
+  setSelectedTab: (tab) => {
+    set({ selectedTab: tab });
   },
   setRestaurantSubpage: (subpage) => {
     set({ restaurantSubpage: subpage });

--- a/frontend/src/types/staticdata.ts
+++ b/frontend/src/types/staticdata.ts
@@ -17,7 +17,7 @@ export interface SelectedRegion {
 export interface Sport {
   id: number;
   name: string;
-  is_team_competition: boolean;
+  isTeamCompetition: boolean;
 }
 
 export interface League {


### PR DESCRIPTION
## 📎 관련 이슈
`#110` 


## 📌 PR 설명
- 식당 상세에서 중계 버튼 클릭시 마이페이지 중계 관리로 이동
- 등록 버튼을 플로팅 버튼으로 변경
- 팀 작성 안되는 종목 선택 시 InputText disabled로 변경
- 중계 일정 탭리스트나 캘린더에서 오늘 날짜로 이동하는 버튼 추가



## ✅ 작업 내용
- [x] 기능 구현
- [x] UI 수정
- [ ] 버그 수정


## 🧪 테스트 방법 (선택)
어떻게 테스트했는지, 테스트할 방법이 있다면 적어주세요.
<img width="320" height="600" alt="스크린샷 2025-07-14 10 46 38" src="https://github.com/user-attachments/assets/972e904c-9a3f-4f17-991d-414e7a9215d2" />
<img width="320" height="600" alt="스크린샷 2025-07-14 10 46 27" src="https://github.com/user-attachments/assets/5d25db77-c421-424b-b4ac-dc6c78cd44ca" />


## 💬 기타
추가로 공유할 내용이나 주의 사항
